### PR TITLE
Disable __builtin_is_constant_evaluated with NVCC in C++11 mode

### DIFF
--- a/.upstream-tests/test/std/utilities/utilities.general/broken_constant_eval.pass.cpp
+++ b/.upstream-tests/test/std/utilities/utilities.general/broken_constant_eval.pass.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This test serves as a canary for when this issue is fixed in NVCC
+//
+// UNSUPPORTED: windows, icc, pgi
+// XFAIL: clang-9 && c++11
+// XFAIL: clang-10 && c++11
+// XFAIL: gcc-9 && c++11
+// XFAIL: gcc-10 && c++11
+
+
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_is_constant_evaluated)
+#define BUILTIN_CONSTANT_EVAL() __builtin_is_constant_evaluated()
+#endif
+#endif
+
+#ifndef BUILTIN_CONSTANT_EVAL
+#define BUILTIN_CONSTANT_EVAL() true
+#endif
+
+__device__ __host__ inline constexpr bool constant_eval() {
+  return BUILTIN_CONSTANT_EVAL();
+}
+
+int main(int, char**) {
+  static_assert(constant_eval(), "");
+  return 0;
+}

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -643,7 +643,8 @@ typedef __char32_t char32_t;
 #define _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(...) __atomic_always_lock_free(__VA_ARGS__)
 #endif
 
-#if __has_builtin(__builtin_is_constant_evaluated)
+// NVCC in C++11 mode freaks out about `__builtin_is_constant_evaluated`.
+#if __has_builtin(__builtin_is_constant_evaluated) && !(defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_STD_VER < 14)
 #define _LIBCUDACXX_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
 #endif
 
@@ -784,11 +785,9 @@ typedef __char32_t char32_t;
 #define _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(...) __atomic_always_lock_free(__VA_ARGS__)
 #endif
 
-#if _GNUC_VER >= 900
-// TODO: figure out why NVCC is unhappy with the builtin, but _only_ in C++11 mode.
-#if __cplusplus > 201103L
+// NVCC in C++11 mode freaks out about `__builtin_is_constant_evaluated`.
+#if _GNUC_VER >= 900 && !(defined(_LIBCUDACXX_COMPILER_NVCC) && _LIBCUDACXX_STD_VER < 14)
 #define _LIBCUDACXX_IS_CONSTANT_EVALUATED(...) __builtin_is_constant_evaluated(__VA_ARGS__)
-#endif
 #endif
 
 #define _LIBCUDACXX_ALWAYS_INLINE __attribute__ ((__always_inline__))


### PR DESCRIPTION
NVCC reports that uses of `__builtin_is_constant_evaluated` in a constexpr evaluation are invalid:

`detail/libcxx/include/type_traits(4835): error #2416-D: constexpr function return is non-constant`

The fix for now is a WAR that removes the use of the builtin when compiling under NVCC:

I've added a test that should let us know when it's functioning again.