### PR TITLE
Add missing inline visibility macro to chrono functions

### DIFF
--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -2010,13 +2010,18 @@ private:
    chrono::day   __d;
 public:
     month_day() = default;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr month_day(const chrono::month& __mval, const chrono::day& __dval) noexcept
         : __m{__mval}, __d{__dval} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::day   day()   const noexcept { return __d; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr bool ok() const noexcept;
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool month_day::ok() const noexcept
 {
@@ -2032,47 +2037,58 @@ bool month_day::ok() const noexcept
     return true;
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const month_day& __lhs, const month_day& __rhs) noexcept
 { return __lhs.month() == __rhs.month() && __lhs.day() == __rhs.day(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const month_day& __lhs, const month_day& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_day operator/(const month& __lhs, const day& __rhs) noexcept
 { return month_day{__lhs, __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr
 month_day operator/(const day& __lhs, const month& __rhs) noexcept
 { return __rhs / __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_day operator/(const month& __lhs, int __rhs) noexcept
 { return __lhs / day(__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr
 month_day operator/(int __lhs, const day& __rhs) noexcept
 { return month(__lhs) / __rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr
 month_day operator/(const day& __lhs, int __rhs) noexcept
 { return month(__rhs) / __lhs; }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator< (const month_day& __lhs, const month_day& __rhs) noexcept
 { return __lhs.month() != __rhs.month() ? __lhs.month() < __rhs.month() : __lhs.day() < __rhs.day(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator> (const month_day& __lhs, const month_day& __rhs) noexcept
 { return __rhs < __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator<=(const month_day& __lhs, const month_day& __rhs) noexcept
 { return !(__rhs < __lhs);}
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator>=(const month_day& __lhs, const month_day& __rhs) noexcept
 { return !(__lhs < __rhs); }
@@ -2083,48 +2099,61 @@ class month_day_last {
 private:
     chrono::month __m;
 public:
+    _LIBCUDACXX_INLINE_VISIBILITY
     explicit constexpr month_day_last(const chrono::month& __val) noexcept
         : __m{__val} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr bool ok() const noexcept { return __m.ok(); }
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const month_day_last& __lhs, const month_day_last& __rhs) noexcept
 { return __lhs.month() == __rhs.month(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const month_day_last& __lhs, const month_day_last& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator< (const month_day_last& __lhs, const month_day_last& __rhs) noexcept
 { return __lhs.month() < __rhs.month(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator> (const month_day_last& __lhs, const month_day_last& __rhs) noexcept
 { return __rhs < __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator<=(const month_day_last& __lhs, const month_day_last& __rhs) noexcept
 { return !(__rhs < __lhs);}
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator>=(const month_day_last& __lhs, const month_day_last& __rhs) noexcept
 { return !(__lhs < __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_day_last operator/(const month& __lhs, last_spec) noexcept
 { return month_day_last{__lhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_day_last operator/(last_spec, const month& __rhs) noexcept
 { return month_day_last{__rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_day_last operator/(int __lhs, last_spec) noexcept
 { return month_day_last{month(__lhs)}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_day_last operator/(last_spec, int __rhs) noexcept
 { return month_day_last{month(__rhs)}; }
@@ -2136,33 +2165,43 @@ private:
     chrono::weekday_indexed __wdi;
 public:
     month_weekday() = default;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr month_weekday(const chrono::month& __mval, const chrono::weekday_indexed& __wdival) noexcept
         : __m{__mval}, __wdi{__wdival} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month                     month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept { return __wdi; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr bool                                 ok() const noexcept { return __m.ok() && __wdi.ok(); }
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const month_weekday& __lhs, const month_weekday& __rhs) noexcept
 { return __lhs.month() == __rhs.month() && __lhs.weekday_indexed() == __rhs.weekday_indexed(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const month_weekday& __lhs, const month_weekday& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday operator/(const month& __lhs, const weekday_indexed& __rhs) noexcept
 { return month_weekday{__lhs, __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday operator/(int __lhs, const weekday_indexed& __rhs) noexcept
 { return month_weekday{month(__lhs), __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday operator/(const weekday_indexed& __lhs, const month& __rhs) noexcept
 { return month_weekday{__rhs, __lhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday operator/(const weekday_indexed& __lhs, int __rhs) noexcept
 { return month_weekday{month(__rhs), __lhs}; }
@@ -2172,34 +2211,44 @@ class month_weekday_last {
     chrono::month        __m;
     chrono::weekday_last __wdl;
   public:
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr month_weekday_last(const chrono::month& __mval, const chrono::weekday_last& __wdlval) noexcept
         : __m{__mval}, __wdl{__wdlval} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month               month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::weekday_last weekday_last() const noexcept { return __wdl; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr bool                           ok() const noexcept { return __m.ok() && __wdl.ok(); }
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const month_weekday_last& __lhs, const month_weekday_last& __rhs) noexcept
 { return __lhs.month() == __rhs.month() && __lhs.weekday_last() == __rhs.weekday_last(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const month_weekday_last& __lhs, const month_weekday_last& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday_last operator/(const month& __lhs, const weekday_last& __rhs) noexcept
 { return month_weekday_last{__lhs, __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday_last operator/(int __lhs, const weekday_last& __rhs) noexcept
 { return month_weekday_last{month(__lhs), __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday_last operator/(const weekday_last& __lhs, const month& __rhs) noexcept
 { return month_weekday_last{__rhs, __lhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 month_weekday_last operator/(const weekday_last& __lhs, int __rhs) noexcept
 { return month_weekday_last{month(__rhs), __lhs}; }
@@ -2210,47 +2259,64 @@ class year_month {
     chrono::month __m;
 public:
     year_month() = default;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month(const chrono::year& __yval, const chrono::month& __mval) noexcept
         : __y{__yval}, __m{__mval} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::year  year()  const noexcept { return __y; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr year_month& operator+=(const months& __dm) noexcept { this->__m += __dm; return *this; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr year_month& operator-=(const months& __dm) noexcept { this->__m -= __dm; return *this; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr year_month& operator+=(const years& __dy)  noexcept { this->__y += __dy; return *this; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr year_month& operator-=(const years& __dy)  noexcept { this->__y -= __dy; return *this; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr bool ok() const noexcept { return __y.ok() && __m.ok(); }
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month operator/(const year& __y, const month& __m) noexcept { return year_month{__y, __m}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month operator/(const year& __y, int __m) noexcept { return year_month{__y, month(__m)}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const year_month& __lhs, const year_month& __rhs) noexcept
 { return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const year_month& __lhs, const year_month& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator< (const year_month& __lhs, const year_month& __rhs) noexcept
 { return __lhs.year() != __rhs.year() ? __lhs.year() < __rhs.year() : __lhs.month() < __rhs.month(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator> (const year_month& __lhs, const year_month& __rhs) noexcept
 { return __rhs < __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator<=(const year_month& __lhs, const year_month& __rhs) noexcept
 { return !(__rhs < __lhs);}
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator>=(const year_month& __lhs, const year_month& __rhs) noexcept
 { return !(__lhs < __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr year_month operator+(const year_month& __lhs, const months& __rhs) noexcept
 {
     int __dmi = static_cast<int>(static_cast<unsigned>(__lhs.month())) - 1 + __rhs.count();
@@ -2259,21 +2325,27 @@ constexpr year_month operator+(const year_month& __lhs, const months& __rhs) noe
     return (__lhs.year() + years(__dy)) / month(static_cast<unsigned>(__dmi));
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr year_month operator+(const months& __lhs, const year_month& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr year_month operator+(const year_month& __lhs, const years& __rhs) noexcept
 { return (__lhs.year() + __rhs) / __lhs.month(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr year_month operator+(const years& __lhs, const year_month& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr months     operator-(const year_month& __lhs, const year_month& __rhs) noexcept
 { return (__lhs.year() - __rhs.year()) + months(static_cast<unsigned>(__lhs.month()) - static_cast<unsigned>(__rhs.month())); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr year_month operator-(const year_month& __lhs, const months& __rhs) noexcept
 { return __lhs + -__rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr year_month operator-(const year_month& __lhs, const years& __rhs) noexcept
 { return __lhs + -__rhs; }
 
@@ -2286,34 +2358,50 @@ private:
     chrono::day   __d;
 public:
      year_month_day() = default;
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr year_month_day(
             const chrono::year& __yval, const chrono::month& __mval, const chrono::day& __dval) noexcept
             : __y{__yval}, __m{__mval}, __d{__dval} {}
             constexpr year_month_day(const year_month_day_last& __ymdl) noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr year_month_day(const sys_days& __sysd) noexcept
             : year_month_day(__from_days(__sysd.time_since_epoch())) {}
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline explicit constexpr year_month_day(const local_days& __locd) noexcept
             : year_month_day(__from_days(__locd.time_since_epoch())) {}
 
+     _LIBCUDACXX_INLINE_VISIBILITY
             constexpr year_month_day& operator+=(const months& __dm) noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
             constexpr year_month_day& operator-=(const months& __dm) noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
             constexpr year_month_day& operator+=(const years& __dy)  noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
             constexpr year_month_day& operator-=(const years& __dy)  noexcept;
 
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr chrono::year   year() const noexcept { return __y; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr chrono::month month() const noexcept { return __m; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr chrono::day     day() const noexcept { return __d; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr operator   sys_days() const noexcept          { return   sys_days{__to_days()}; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline explicit constexpr operator local_days() const noexcept { return local_days{__to_days()}; }
 
+     _LIBCUDACXX_INLINE_VISIBILITY
             constexpr bool             ok() const noexcept;
 
+     _LIBCUDACXX_INLINE_VISIBILITY
      static constexpr year_month_day __from_days(days __d) noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
      constexpr days __to_days() const noexcept;
 };
 
 
 // https://howardhinnant.github.io/date_algorithms.html#civil_from_days
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day
 year_month_day::__from_days(days __d) noexcept
@@ -2333,6 +2421,7 @@ year_month_day::__from_days(days __d) noexcept
 }
 
 // https://howardhinnant.github.io/date_algorithms.html#days_from_civil
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr days year_month_day::__to_days() const noexcept
 {
     static_assert(std::numeric_limits<unsigned>::digits >= 18, "");
@@ -2349,14 +2438,17 @@ inline constexpr days year_month_day::__to_days() const noexcept
     return days{__era * 146097 + static_cast<int>(__doe) - 719468};
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const year_month_day& __lhs, const year_month_day& __rhs) noexcept
 { return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() && __lhs.day() == __rhs.day(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const year_month_day& __lhs, const year_month_day& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator< (const year_month_day& __lhs, const year_month_day& __rhs) noexcept
 {
@@ -2367,70 +2459,89 @@ bool operator< (const year_month_day& __lhs, const year_month_day& __rhs) noexce
     return __lhs.day() < __rhs.day();
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator> (const year_month_day& __lhs, const year_month_day& __rhs) noexcept
 { return __rhs < __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator<=(const year_month_day& __lhs, const year_month_day& __rhs) noexcept
 { return !(__rhs < __lhs);}
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator>=(const year_month_day& __lhs, const year_month_day& __rhs) noexcept
 { return !(__lhs < __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator/(const year_month& __lhs, const day& __rhs) noexcept
 { return year_month_day{__lhs.year(), __lhs.month(), __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator/(const year_month& __lhs, int __rhs) noexcept
 { return __lhs / day(__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator/(const year& __lhs, const month_day& __rhs) noexcept
 { return __lhs / __rhs.month() / __rhs.day(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator/(int __lhs, const month_day& __rhs) noexcept
 { return year(__lhs) / __rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator/(const month_day& __lhs, const year& __rhs) noexcept
 { return __rhs / __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator/(const month_day& __lhs, int __rhs) noexcept
 { return year(__rhs) / __lhs; }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator+(const year_month_day& __lhs, const months& __rhs) noexcept
 { return (__lhs.year()/__lhs.month() + __rhs)/__lhs.day(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator+(const months& __lhs, const year_month_day& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator-(const year_month_day& __lhs, const months& __rhs) noexcept
 { return __lhs + -__rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator+(const year_month_day& __lhs, const years& __rhs) noexcept
 { return (__lhs.year() + __rhs) / __lhs.month() / __lhs.day(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator+(const years& __lhs, const year_month_day& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day operator-(const year_month_day& __lhs, const years& __rhs) noexcept
 { return __lhs + -__rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day& year_month_day::operator+=(const months& __dm) noexcept { *this = *this + __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day& year_month_day::operator-=(const months& __dm) noexcept { *this = *this - __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day& year_month_day::operator+=(const years& __dy)  noexcept { *this = *this + __dy; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day& year_month_day::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
 class year_month_day_last {
@@ -2438,23 +2549,36 @@ private:
     chrono::year           __y;
     chrono::month_day_last __mdl;
 public:
+     _LIBCUDACXX_INLINE_VISIBILITY
      constexpr year_month_day_last(const year& __yval, const month_day_last& __mdlval) noexcept
         : __y{__yval}, __mdl{__mdlval} {}
 
+     _LIBCUDACXX_INLINE_VISIBILITY
      constexpr year_month_day_last& operator+=(const months& __m) noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
      constexpr year_month_day_last& operator-=(const months& __m) noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
      constexpr year_month_day_last& operator+=(const years& __y)  noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
      constexpr year_month_day_last& operator-=(const years& __y)  noexcept;
 
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr chrono::year                     year() const noexcept { return __y; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr chrono::month                   month() const noexcept { return __mdl.month(); }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr chrono::month_day_last month_day_last() const noexcept { return __mdl; }
+     _LIBCUDACXX_INLINE_VISIBILITY
             constexpr chrono::day                       day() const noexcept;
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr operator                     sys_days() const noexcept { return   sys_days{year()/month()/day()}; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline explicit constexpr operator          local_days() const noexcept { return local_days{year()/month()/day()}; }
+     _LIBCUDACXX_INLINE_VISIBILITY
      inline constexpr bool                               ok() const noexcept { return __y.ok() && __mdl.ok(); }
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 chrono::day year_month_day_last::day() const noexcept
 {
@@ -2469,14 +2593,17 @@ chrono::day year_month_day_last::day() const noexcept
         __d[static_cast<unsigned>(month()) - 1] : chrono::day{29};
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept
 { return __lhs.year() == __rhs.year() && __lhs.month_day_last() == __rhs.month_day_last(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator< (const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept
 {
@@ -2485,66 +2612,86 @@ bool operator< (const year_month_day_last& __lhs, const year_month_day_last& __r
     return __lhs.month_day_last() < __rhs.month_day_last();
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator> (const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept
 { return __rhs < __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator<=(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept
 { return !(__rhs < __lhs);}
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator>=(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept
 { return !(__lhs < __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last operator/(const year_month& __lhs, last_spec) noexcept
 { return year_month_day_last{__lhs.year(), month_day_last{__lhs.month()}}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last operator/(const year& __lhs, const month_day_last& __rhs) noexcept
 { return year_month_day_last{__lhs, __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last operator/(int __lhs, const month_day_last& __rhs) noexcept
 { return year_month_day_last{year{__lhs}, __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last operator/(const month_day_last& __lhs, const year& __rhs) noexcept
 { return __rhs / __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last operator/(const month_day_last& __lhs, int __rhs) noexcept
 { return year{__rhs} / __lhs; }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day_last operator+(const year_month_day_last& __lhs, const months& __rhs) noexcept
 { return (__lhs.year() / __lhs.month() + __rhs) / last; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day_last operator+(const months& __lhs, const year_month_day_last& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day_last operator-(const year_month_day_last& __lhs, const months& __rhs) noexcept
 { return __lhs + (-__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day_last operator+(const year_month_day_last& __lhs, const years& __rhs) noexcept
 { return year_month_day_last{__lhs.year() + __rhs, __lhs.month_day_last()}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day_last operator+(const years& __lhs, const year_month_day_last& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_day_last operator-(const year_month_day_last& __lhs, const years& __rhs) noexcept
 { return __lhs + (-__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last& year_month_day_last::operator+=(const months& __dm) noexcept { *this = *this + __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last& year_month_day_last::operator-=(const months& __dm) noexcept { *this = *this - __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last& year_month_day_last::operator+=(const years& __dy)  noexcept { *this = *this + __dy; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day_last& year_month_day_last::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_day::year_month_day(const year_month_day_last& __ymdl) noexcept
     : __y{__ymdl.year()}, __m{__ymdl.month()}, __d{__ymdl.day()} {}
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr bool year_month_day::ok() const noexcept
 {
     if (!__y.ok() || !__m.ok()) return false;
@@ -2557,26 +2704,41 @@ class year_month_weekday {
     chrono::weekday_indexed __wdi;
 public:
     year_month_weekday() = default;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday(const chrono::year& __yval, const chrono::month& __mval,
                                const chrono::weekday_indexed& __wdival) noexcept
         : __y{__yval}, __m{__mval}, __wdi{__wdival} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday(const sys_days& __sysd) noexcept
             : year_month_weekday(__from_days(__sysd.time_since_epoch())) {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline explicit constexpr year_month_weekday(const local_days& __locd) noexcept
             : year_month_weekday(__from_days(__locd.time_since_epoch())) {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday& operator+=(const months& m) noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday& operator-=(const months& m) noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday& operator+=(const years& y)  noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday& operator-=(const years& y)  noexcept;
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::year                       year() const noexcept { return __y; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month                     month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::weekday                 weekday() const noexcept { return __wdi.weekday(); }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr unsigned                          index() const noexcept { return __wdi.index(); }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept { return __wdi; }
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr                       operator sys_days() const noexcept { return   sys_days{__to_days()}; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline explicit constexpr operator            local_days() const noexcept { return local_days{__to_days()}; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr bool ok() const noexcept
     {
         if (!__y.ok() || !__m.ok() || !__wdi.ok()) return false;
@@ -2584,10 +2746,13 @@ public:
         return true;
     }
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr year_month_weekday __from_days(days __d) noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr days __to_days() const noexcept;
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday year_month_weekday::__from_days(days __d) noexcept
 {
@@ -2598,6 +2763,7 @@ year_month_weekday year_month_weekday::__from_days(days __d) noexcept
                               __wd[(static_cast<unsigned>(__ymd.day())-1)/7+1]};
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 days year_month_weekday::__to_days() const noexcept
 {
@@ -2606,63 +2772,80 @@ days year_month_weekday::__to_days() const noexcept
                 .time_since_epoch();
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const year_month_weekday& __lhs, const year_month_weekday& __rhs) noexcept
 { return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() && __lhs.weekday_indexed() == __rhs.weekday_indexed(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const year_month_weekday& __lhs, const year_month_weekday& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator/(const year_month& __lhs, const weekday_indexed& __rhs) noexcept
 { return year_month_weekday{__lhs.year(), __lhs.month(), __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator/(const year& __lhs, const month_weekday& __rhs) noexcept
 { return year_month_weekday{__lhs, __rhs.month(), __rhs.weekday_indexed()}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator/(int __lhs, const month_weekday& __rhs) noexcept
 { return year(__lhs) / __rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator/(const month_weekday& __lhs, const year& __rhs) noexcept
 { return __rhs / __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator/(const month_weekday& __lhs, int __rhs) noexcept
 { return year(__rhs) / __lhs; }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator+(const year_month_weekday& __lhs, const months& __rhs) noexcept
 { return (__lhs.year() / __lhs.month() + __rhs) / __lhs.weekday_indexed(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator+(const months& __lhs, const year_month_weekday& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator-(const year_month_weekday& __lhs, const months& __rhs) noexcept
 { return __lhs + (-__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator+(const year_month_weekday& __lhs, const years& __rhs) noexcept
 { return year_month_weekday{__lhs.year() + __rhs, __lhs.month(), __lhs.weekday_indexed()}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator+(const years& __lhs, const year_month_weekday& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday operator-(const year_month_weekday& __lhs, const years& __rhs) noexcept
 { return __lhs + (-__rhs); }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday& year_month_weekday::operator+=(const months& __dm) noexcept { *this = *this + __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday& year_month_weekday::operator-=(const months& __dm) noexcept { *this = *this - __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday& year_month_weekday::operator+=(const years& __dy)  noexcept { *this = *this + __dy; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday& year_month_weekday::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
 class year_month_weekday_last {
@@ -2671,26 +2854,40 @@ private:
     chrono::month        __m;
     chrono::weekday_last __wdl;
 public:
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday_last(const chrono::year& __yval, const chrono::month& __mval,
                                       const chrono::weekday_last& __wdlval) noexcept
                 : __y{__yval}, __m{__mval}, __wdl{__wdlval} {}
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday_last& operator+=(const months& __dm) noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday_last& operator-=(const months& __dm) noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday_last& operator+=(const years& __dy)  noexcept;
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr year_month_weekday_last& operator-=(const years& __dy)  noexcept;
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::year                 year() const noexcept { return __y; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::month               month() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::weekday           weekday() const noexcept { return __wdl.weekday(); }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr chrono::weekday_last weekday_last() const noexcept { return __wdl; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr operator                 sys_days() const noexcept { return   sys_days{__to_days()}; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline explicit constexpr operator      local_days() const noexcept { return local_days{__to_days()}; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     inline constexpr bool ok() const noexcept { return __y.ok() && __m.ok() && __wdl.ok(); }
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr days __to_days() const noexcept;
 
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 days year_month_weekday_last::__to_days() const noexcept
 {
@@ -2699,63 +2896,80 @@ days year_month_weekday_last::__to_days() const noexcept
 
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator==(const year_month_weekday_last& __lhs, const year_month_weekday_last& __rhs) noexcept
 { return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() && __lhs.weekday_last() == __rhs.weekday_last(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 bool operator!=(const year_month_weekday_last& __lhs, const year_month_weekday_last& __rhs) noexcept
 { return !(__lhs == __rhs); }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator/(const year_month& __lhs, const weekday_last& __rhs) noexcept
 { return year_month_weekday_last{__lhs.year(), __lhs.month(), __rhs}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator/(const year& __lhs, const month_weekday_last& __rhs) noexcept
 { return year_month_weekday_last{__lhs, __rhs.month(), __rhs.weekday_last()}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator/(int __lhs, const month_weekday_last& __rhs) noexcept
 { return year(__lhs) / __rhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator/(const month_weekday_last& __lhs, const year& __rhs) noexcept
 { return __rhs / __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator/(const month_weekday_last& __lhs, int __rhs) noexcept
 { return year(__rhs) / __lhs; }
 
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator+(const year_month_weekday_last& __lhs, const months& __rhs) noexcept
 { return (__lhs.year() / __lhs.month() + __rhs) / __lhs.weekday_last(); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator+(const months& __lhs, const year_month_weekday_last& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator-(const year_month_weekday_last& __lhs, const months& __rhs) noexcept
 { return __lhs + (-__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator+(const year_month_weekday_last& __lhs, const years& __rhs) noexcept
 { return year_month_weekday_last{__lhs.year() + __rhs, __lhs.month(), __lhs.weekday_last()}; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator+(const years& __lhs, const year_month_weekday_last& __rhs) noexcept
 { return __rhs + __lhs; }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 year_month_weekday_last operator-(const year_month_weekday_last& __lhs, const years& __rhs) noexcept
 { return __lhs + (-__rhs); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(const months& __dm) noexcept { *this = *this + __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const months& __dm) noexcept { *this = *this - __dm; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(const years& __dy)  noexcept { *this = *this + __dy; return *this; }
+_LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const years& __dy)  noexcept { *this = *this - __dy; return *this; }
 
 
@@ -2766,6 +2980,7 @@ private:
     static_assert(__is_duration<_Duration>::value, "template parameter of hh_mm_ss must be a std::chrono::duration");
     using __CommonType = common_type_t<_Duration, chrono::seconds>;
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr uint64_t __pow10(unsigned __exp)
     {
         uint64_t __ret = 1;
@@ -2774,6 +2989,7 @@ private:
         return __ret;
     }
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0)
     {
         if (__n >= 2 && __d != 0 && __w < 19)
@@ -2826,6 +3042,8 @@ private:
     chrono::seconds __s;
     precision       __f;
 };
+
+#endif // _LIBCUDACXX_STD_VER > 17
 
 _LIBCUDACXX_INLINE_VISIBILITY
 constexpr bool is_am(const hours& __h) noexcept { return __h >= hours( 0) && __h < hours(12); }

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -2786,8 +2786,10 @@ public:
                                                  __width(__CommonType::period::den) : 6u;
     using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr explicit hh_mm_ss(_Duration __d) noexcept :
         __is_neg(__d < _Duration(0)),
         __h(duration_cast<chrono::hours>  (abs(__d))),
@@ -2796,18 +2798,25 @@ public:
         __f(duration_cast<precision>      (abs(__d) - hours() - minutes() - seconds()))
         {}
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr bool is_negative()        const noexcept { return __is_neg; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr chrono::hours hours()     const noexcept { return __h; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr chrono::minutes minutes() const noexcept { return __m; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr chrono::seconds seconds() const noexcept { return __s; }
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr precision subseconds()    const noexcept { return __f; }
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr precision to_duration() const noexcept
     {
         auto __dur = __h + __m + __s + __f;
         return __is_neg ? -__dur : __dur;
     }
 
+    _LIBCUDACXX_INLINE_VISIBILITY
     constexpr explicit operator precision() const noexcept { return to_duration(); }
 
 private:
@@ -2818,9 +2827,12 @@ private:
     precision       __f;
 };
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr bool is_am(const hours& __h) noexcept { return __h >= hours( 0) && __h < hours(12); }
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr bool is_pm(const hours& __h) noexcept { return __h >= hours(12) && __h < hours(24); }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr hours make12(const hours& __h) noexcept
 {
     if      (__h == hours( 0)) return hours(12);
@@ -2828,6 +2840,7 @@ constexpr hours make12(const hours& __h) noexcept
     else                       return __h - hours(12);
 }
 
+_LIBCUDACXX_INLINE_VISIBILITY
 constexpr hours make24(const hours& __h, bool __is_pm) noexcept
 {
     if (__is_pm)


### PR DESCRIPTION
Some functions from libc++'s `<chrono>` were missing the `_LIBCUDACXX_INLINE_VISIBILITY` macro. Therefore, they weren't being decorated with `__host__ __device__` and failing in the tests I am porting for https://github.com/NVIDIA/libcudacxx/pull/10. 