### PR TITLE
Docs: Shard metadata, copy-edit synchronization library docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,93 +28,10 @@ defaults:
       nav_order: 0
   -
     scope:
-      path: setup.md
-    values:
-      has_children: true
-      has_toc: true
-      nav_order: 1
-  -
-    scope:
-      path: setup/requirements.md
-    values:
-      parent: Setup
-      nav_order: 0
-  -
-    scope:
-      path: setup/getting.md
-    values:
-      parent: Setup
-      nav_order: 1
-  -
-    scope:
-      path: setup/building_and_testing.md
-    values:
-      parent: Setup
-      nav_order: 2
-  -
-    scope:
-      path: api.md
-    values:
-      has_children: true
-      has_toc: false
-      nav_order: 2
-  -
-    scope:
-      path: api/synchronization_library.md
-    values:
-      parent: API
-      has_children: true
-      has_toc: false
-      nav_order: 0
-  -
-    scope:
       path: api/synchronization_library/header_table.md
     values:
       parent: API
       nav_exclude: true
-  -
-    scope:
-      path: api/synchronization_library/thread_scopes.md
-    values:
-      grand_parent: API
-      parent: Synchronization Library
-      nav_order: 0
-  -
-    scope:
-      path: api/synchronization_library/atomic.md
-    values:
-      grand_parent: API
-      parent: Synchronization Library
-      nav_order: 1
-  -
-    scope:
-      path: api/synchronization_library/barrier.md
-    values:
-      grand_parent: API
-      parent: Synchronization Library
-      nav_order: 2
-  -
-    scope:
-      path: api/synchronization_library/latch.md
-    values:
-      grand_parent: API
-      parent: Synchronization Library
-      nav_order: 3
-  -
-    scope:
-      path: api/synchronization_library/semaphore.md
-    values:
-      grand_parent: API
-      parent: Synchronization Library
-      nav_order: 4
-  -
-    scope:
-      path: api/time_library.md
-    values:
-      parent: API
-      has_children: true
-      has_toc: false
-      nav_order: 1
   -
     scope:
       path: api/time_library/header_table.md
@@ -123,73 +40,13 @@ defaults:
       nav_exclude: true
   -
     scope:
-      path: api/time_library/chrono.md
-    values:
-      grand_parent: API
-      parent: Time Library
-  -
-    scope:
-      path: api/utility_library.md
-    values:
-      parent: API
-      has_children: true
-      has_toc: false
-      nav_order: 2
-  -
-    scope:
       path: api/utility_library/header_table.md
     values:
       parent: API
       nav_exclude: true
   -
     scope:
-      path: api/utility_library/functional.md
-    values:
-      grand_parent: API
-      parent: Utility Library
-      nav_order: 0
-  -
-    scope:
-      path: api/utility_library/tuple.md
-    values:
-      grand_parent: API
-      parent: Utility Library
-      nav_order: 2
-  -
-    scope:
-      path: api/utility_library/utility.md
-    values:
-      grand_parent: API
-      parent: Utility Library
-      nav_order: 3
-  -
-    scope:
-      path: api/utility_library/version.md
-    values:
-      grand_parent: API
-      parent: Utility Library
-      nav_order: 4
-  -
-    scope:
-      path: releases.md
-    values:
-      has_children: true
-      has_toc: true
-      nav_order: 3
-  -
-    scope:
-      path: releases/*
-    values:
-      parent: Releases
-  -
-    scope:
-      path: contributing.md
-    values:
-      has_children: true
-      has_toc: true
-      nav_order: 4
-  -
-    scope:
-      path: contributing/*
+      path: contributing/code_of_conduct.md
     values:
       parent: Contributing
+      nav_order: 0

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,9 @@
+---
+has_children: true
+has_toc: false
+nav_order: 2
+---
+
 # API
 
 Any header not listed below is omitted.

--- a/docs/api/synchronization_library.md
+++ b/docs/api/synchronization_library.md
@@ -1,10 +1,23 @@
+---
+parent: API
+has_children: true
+has_toc: false
+nav_order: 0
+---
+
 # Synchronization Library
 
-Most synchronization primitives have an additional thread scope template parameter,
-  which defines the set of threads that may interact with the object.
+Most synchronization primitives have an additional thread scope template
+  parameter, which defines the set of threads that may interact with the object.
 Please see the [thread scope section] for more details.
 
+Any header not listed below is omitted.
+
+*: Some the Standard C++ facilities in this header are omitted, see the libcu++
+Addendum for details.
+
 {% include_relative synchronization_library/header_table.md %}
+
 
 [thread scope section]: ./synchronization_library/thread_scopes.md
 

--- a/docs/api/synchronization_library/atomic.md
+++ b/docs/api/synchronization_library/atomic.md
@@ -1,56 +1,75 @@
+---
+grand_parent: API
+parent: Synchronization Library
+nav_order: 1
+---
+
 # `<cuda/std/atomic>`, `<cuda/atomic>`
 
-## Extensions in the `cuda::` namespace
+## Extensions
 
-The class template `atomic` takes an additional scope argument, defaulted to `thread_scope_system`.
+The class template `atomic` takes an additional [thread scope] argument,
+  defaulted to `thread_scope_system`.
 
 ```c++
-// This object is atomic for all threads in the system
-cuda::atomic<int> a; 
+// This atomic is suitable for all threads in the system.
+cuda::atomic<int, cuda::thread_scope_system> a;
 
-// This object has the same type as the previous
-cuda::atomic<int, cuda::thread_scope_system> b; 
+// This atomic has the same type as the previous one (`a`).
+cuda::atomic<int> b;
 
-// This object is atomic for threads in the same thread block
-cuda::atomic<int, cuda::thread_scope_block> c; 
+// This atomic is suitable for threads in the same thread block.
+cuda::atomic<int, cuda::thread_scope_block> c;
 ```
 
-The `atomic` class template specializations for integral and pointer types are extended with members `fetch_min` and `fetch_max`. These conform to the requirements in `[atomics.types.int]` and `[atomics.types.pointer]`, with keys _min_ and _max_, and operations `min` and `max`, respectively.
+The `atomic` class template specializations for integral and pointer types are
+extended with members `fetch_min` and `fetch_max`.
+These conform to the requirements in section [atomics.types.int] and
+  [atomics.types.pointer] of ISO/IEC IS 14882 (the C++ Standard),
+  with keys _min_ and _max_, and operations `min` and `max`, respectively.
 
-Note that conformance to these requirements include implicit conversions to unsigned types, if applicable.
+Note that conformance to these requirements include implicit conversions to
+  unsigned types, if applicable.
 
 ```c++
-cuda::atomic<int> a(1); 
-auto x = a.fetch_min(0); // operates as if unsigned
+cuda::atomic<int> a(1);
+auto x = a.fetch_min(0); // Operates as if unsigned.
 auto y = a.load();
 assert(x == 1 && y == 0);
 ```
 
-## Omissions
-
-None relative to libcxx.
-
 ## Restrictions
 
-An object of type `atomic` shall not be accessed concurrently by CPU and GPU threads unless:
-  1. it is in managed memory, with `concurrentManagedAccess==1`, or
-  2. it is in host memory, with `hostNativeAtomicSupported==1`.
+An object of type `atomic` shall not be accessed concurrently by CPU and GPU
+  threads unless:
+- it is in unified memory and the [`concurrentManagedAccess` property] is 1, or
+- it is in CPU memory and the [`hostNativeAtomicSupported` property] is 1.
 
-(Note, for objects of scopes other than `thread_scope_system` this is a data-race, and thefore also prohibited regardless of memory characteristics.)
+Note, for objects of scopes other than `thread_scope_system` this is a
+  data-race, and thefore also prohibited regardless of memory characteristics.
 
-Under Compute Capability 6, an object of type `atomic` may not be used:
-  1. with automatic storage duration, or 
-  2. if `is_always_lock_free()` returns `false`.
+Under CUDA Compute Capability 6 (Pascal), an object of type `atomic` may not be
+  used:
+- with automatic storage duration, or
+- if `is_always_lock_free()` is `false`.
 
-Under Compute Capability prior to 6, objects of type `atomic` may not be used.
+Under CUDA Compute Capability prior to 6 (Pascal), objects of type `atomic` may
+not be used.
 
 ## Implementation-Defined Behavior
 
-For each type `T` and scope `S`, the value of `atomic<T,S>::is_always_lock_free()` is as follows:
+For each type `T` and [thread scope] `S`, the value of
+  `atomic<T, S>::is_always_lock_free()` is as follows:
 
-|Type `T`|Scope `S`|`atomic<T,S>::is_always_lock_free()`|
-|-|-|-|
-|Any|Any|`sizeof(T) <= 8`|
+|Type `T`|Thread Scope `S`|`atomic<T, S>::is_always_lock_free()`|
+|--------|----------------|-------------------------------------|
+|Any     |Any             |`sizeof(T) <= 8`                     |
 
 
-Objects in namespace `cuda::std::` have the same behavior as corresponding objects in namespace `cuda::` when instantiated with a scope of `cuda::thread_scope_system`.
+[thread scope]: ./thread_scopes.md
+
+[atomics.types.int]: https://eel.is/c++draft/atomics.types.int
+[atomics.types.pointer]: https://eel.is/c++draft/atomics.types.pointer
+
+[`concurrentManagedAccess` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b
+[`hostNativeAtomicSupported` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f

--- a/docs/api/synchronization_library/barrier.md
+++ b/docs/api/synchronization_library/barrier.md
@@ -1,29 +1,41 @@
+---
+grand_parent: API
+parent: Synchronization Library
+nav_order: 2
+---
+
 # `<cuda/std/barrier>`, `<cuda/barrier>`
 
-## Extensions in the `cuda::` namespace
+## Extensions
 
-The class template `barrier` takes an additional scope argument, defaulted to `thread_scope_system`.
-
-```c++
-// This object is barrier suitable for all threads in the system
-cuda::barrier<> a; 
-
-// This object has the same type as the previous
-cuda::barrier<cuda::thread_scope_system> b; 
-
-// This object is a barrier for threads in the same thread block
-cuda::barrier<cuda::thread_scope_block> c; 
-```
-
-The class template `barrier` may also be declared without initialization; a new static member `init` that be used to initialize the object.
+The class template `barrier` takes an additional [thread scope] argument,
+  defaulted to `thread_scope_system`.
 
 ```c++
-__shared__ cuda::barrier<cuda::thread_scope_block> b; // shared memory does not allow initialization
+// This barrier is suitable for all threads in the system.
+cuda::barrier<cuda::thread_scope_system> a;
 
-init(&b, 1); // use this free function to initialize this object
+// These barriers have the same type as the previous one.
+cuda::barrier<> ba;
+cuda::std::barrier<> bb;
+
+// This barrier is suitable for all threads in the same thread block.
+cuda::barrier<cuda::thread_scope_block> c;
 ```
 
-In the `device::` sub-namespace a `__device__` free function is available that provides direct access to the underlying PTX state of a `barrier` object, if its scope is `thread_scope_block` and it is allocated in shared memory.
+The class template `barrier` may also be declared without initialization; a
+friend function `init` may be used to initialize the object.
+
+```c++
+// Shared memory does not allow initialization.
+__shared__ cuda::barrier<cuda::thread_scope_block> b;
+
+init(&b, 1); // Use this friend function to initialize the object.
+```
+
+In the `device::` namespace, a `__device__` free function is available that
+  provides direct access to the underlying PTX state of a `barrier` object, if
+  its scope is `thread_scope_block` and it is allocated in shared memory.
 
 ```c++
 namespace cuda { namespace device {
@@ -33,8 +45,9 @@ __device__ std::uint64_t* barrier_native_handle(
 
 }}
 ```
-* Expects: `b` is in shared memory;
-* Returns: a pointer to the PTX "mbarrier" subobject of the `barrier` object.
+
+- Expects: `b` is in `__shared__` memory.
+- Returns: a pointer to the PTX "mbarrier" subobject of the `barrier` object.
 
 For example:
 
@@ -44,34 +57,48 @@ auto ptr = barrier_native_handle(b);
 asm volatile (
     "mbarrier.arrive.b64 _, [%0];"
     :: "l"(ptr)
-    : "memory"); 
+    : "memory");
 // equivalent to: (void)b.arrive();
 ```
 
-## Omissions
-
-None.
-
 ## Restrictions
 
-An object of type `barrier` shall not be accessed concurrently by CPU and GPU threads unless:
-  1. it is in managed memory, with `concurrentManagedAccess==1`, or
-  2. it is in host memory, with `hostNativeAtomicSupported==1`.
+An object of type `barrier` shall not be accessed concurrently by CPU and GPU
+  threads unless:
+- it is in unified memory and the [`concurrentManagedAccess` property] is 1, or
+- it is in CPU memory and the [`hostNativeAtomicSupported` property] is 1.
 
-(Note, for objects of scopes other than `thread_scope_system` this is a data-race, and thefore also prohibited regardless of memory characteristics.)
+Note, for objects of scopes other than `thread_scope_system` this is a
+  data-race, and thefore also prohibited regardless of memory characteristics.
 
-Under Compute Capability 8 or above, when an object of type `barrier<thread_scope_block>` is placed in `__shared__` memory, the member function `arrive` performs a reduction of the arrival count among [coalesced](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#coalesced-group-cg) threads followed by the arrival operation in one thread. Programs shall ensure that this transformation would not introduce errors, for example relative to the requirements of `[thread.barrier.class]` paragraph 12 in N4860.
+Under CUDA Compute Capability 8 (Ampere) or above, when an object of type
+  `barrier<thread_scope_block>` is placed in `__shared__` memory, the member
+  function `arrive` performs a reduction of the arrival count among
+  [coalesced threads] followed by the arrival operation in one thread.
+Programs shall ensure that this transformation would not introduce errors, for
+  example relative to the requirements of [thread.barrier.class paragraph 12]
+  of ISO/IEC IS 14882 (the C++ Standard).
 
-Under Compute Capability 6 or prior, an object of type `barrier` may not be used.
+Under CUDA Compute Capability 6 (Pascal) or prior, an object of type `barrier`
+  may not be used.
 
 ## Implementation-Defined Behavior
 
-For each scope `S` and completion function `F`, the value of `barrier<S,F>::max()` is as follows:
+For each [thread scope] `S` and completion function `F`, the value of
+  `barrier<S, F>::max()` is as follows:
 
-|Scope `S`|Completion function `F`|`barrier<S,F>::max()`|
-|-|-|-|
-|`thread_scope_block`|Default or user-provided|`(1 << 20) - 1`|
-|Not `thread_scope_block`|Default|`std::numeric_limits<int32_t>::max()`|
-|Not `thread_scope_block`|User-provided|`std::numeric_limits<ptrdiff_t>::max()`|
+|Thread Scope `S`        |Completion Function `F` |`barrier<S, F>::max()`            |
+|------------------------|------------------------|----------------------------------|
+|`thread_scope_block`    |Default or user-provided|`(1 << 20) - 1`                   |
+|Not `thread_scope_block`|Default                 |`numeric_limits<int32_t>::max()`  |
+|Not `thread_scope_block`|User-provided           |`numeric_limits<ptrdiff_t>::max()`|
 
-Objects in namespace `cuda::std::` have the same behavior as corresponding objects in namespace `cuda::` when instantiated with a scope of `cuda::thread_scope_system`.
+
+[thread scope]: ./thread_scopes.md
+
+[thread.barrier.class paragraph 12]: https://eel.is/c++draft/thread.barrier.class#12
+
+[coalesced threads]: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#coalesced-group-cg
+
+[`concurrentManagedAccess` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b
+[`hostNativeAtomicSupported` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f

--- a/docs/api/synchronization_library/latch.md
+++ b/docs/api/synchronization_library/latch.md
@@ -1,40 +1,55 @@
+---
+grand_parent: API
+parent: Synchronization Library
+nav_order: 3
+---
+
 # `<cuda/std/latch>`, `<cuda/latch>`
 
-## Extensions in the `cuda::` namespace
+## Extensions
 
-The class template `latch` takes an additional scope argument, defaulted to `thread_scope_system`.
+The class template `latch` takes an additional [thread scope] argument,
+  defaulted to `thread_scope_system`.
 
 ```c++
-// This object is latch suitable for all threads in the system
-cuda::latch<> a; 
+// This latch is suitable for all threads in the system.
+cuda::latch<cuda::thread_scope_system> a;
 
-// This object has the same type as the previous
-cuda::latch<cuda::thread_scope_system> b; 
+// These latches has the same type as the previous one (`a`).
+cuda::latch<> ba;
+cuda::std::latch<> bb;
 
-// This object is a latch for threads in the same thread block
-cuda::latch<cuda::thread_scope_block> c; 
+// This latch is suitable for all threads in the same thread block.
+cuda::latch<cuda::thread_scope_block> c;
 ```
-
-## Omissions
-
-None.
 
 ## Restrictions
 
-An object of type `latch` shall not be accessed concurrently by CPU and GPU threads unless:
-  1. it is in managed memory, with `concurrentManagedAccess==1`, or
-  2. it is in host memory, with `hostNativeAtomicSupported==1`.
+An object of type `latch` shall not be accessed concurrently by CPU and GPU
+  threads unless:
+- it is in unified memory and the [`concurrentManagedAccess` property] is 1, or
+- it is in CPU memory and the [`hostNativeAtomicSupported` property] is 1.
 
-This requirement is in addition to the requirement to avoid data-races, see [thread scopes]({{ "./thread_scopes.html" | relative_url }}) for more information.
+Note, for objects of scopes other than `thread_scope_system` this is a
+  data-race, and thefore also prohibited regardless of memory characteristics.
 
-Under Compute Capability 6 or prior, an object of type `latch` may not be used.
+Under CUDA Compute Capability 6 (Pascal) or prior, an object of type `latch`
+  may not be used.
 
 ## Implementation-Defined Behavior
 
-For each scope `S`, the value of `latch<S>::max()` is as follows:
+For each [thread scope] `S`, the value of `latch<S>::max()` is as follows:
 
-|Scope `S`|`latch<S>::max()`|
-|-|-|
-|Any|`std::numeric_limits<ptrdiff_t>::max()`|
+|Thread Scope `S`|`latch<S>::max()`                 |
+|----------------|----------------------------------|
+|Any             |`numeric_limits<ptrdiff_t>::max()`|
 
-Objects in namespace `cuda::std::` have the same behavior as corresponding objects in namespace `cuda::` when instantiated with a scope of `cuda::thread_scope_system`.
+Objects in namespace `cuda::std::` have the same behavior as corresponding
+  objects in namespace `cuda::` when instantiated with a scope of
+  `cuda::thread_scope_system`.
+
+
+[thread scope]: ./thread_scopes.md
+
+[`concurrentManagedAccess` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b
+[`hostNativeAtomicSupported` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f

--- a/docs/api/synchronization_library/semaphore.md
+++ b/docs/api/synchronization_library/semaphore.md
@@ -1,51 +1,64 @@
+---
+grand_parent: API
+parent: Synchronization Library
+nav_order: 4
+---
+
 # `<cuda/std/semaphore>`, `<cuda/semaphore>`
 
-## Extensions in the `cuda::` namespace
+## Extensions
 
 The class `binary_semaphore` is a class template in this namespace.
 
-The class templates `binary_semaphore` and `counting_semaphore` take an additional scope argument, defaulted to `thread_scope_system`.
+The class templates `binary_semaphore` and `counting_semaphore` take an
+  additional [thread scope] argument, defaulted to `thread_scope_system`.
 
 ```c++
-// These objects are semaphores suitable for all threads in the system
-cuda::binary_semaphore<> a1; 
-cuda::counting_semaphore<> a2; 
+// These semaphores are suitable for all threads in the system.
+cuda::binary_semaphore<cuda::thread_scope_system> a0;
+cuda::counting_semaphore<cuda::thread_scope_system> a1;
 
-// These objects have the same types as the previous (respectively)
-cuda::binary_semaphore<cuda::thread_scope_system> b1; 
-cuda::counting_semaphore<cuda::thread_scope_system> b2; 
+// These semaphores have the same types as the previous ones (`a0` and `a1` respectively).
+cuda::binary_semaphore<> b0a;
+cuda::std::binary_semaphore b0b;
+cuda::counting_semaphore<> b1a;
+cuda::std::counting_semaphore<> b1b;
 
-// These objects are semaphores for threads in the same thread block
-cuda::binary_semaphore<cuda::thread_scope_block> c1; 
-cuda::counting_semaphore<cuda::thread_scope_block> c2; 
+// These semaphores are suitable for all threads in the same thread block.
+cuda::binary_semaphore<cuda::thread_scope_block> c0;
+cuda::counting_semaphore<cuda::thread_scope_block> c1;
 ```
-
-## Omissions
-
-None.
 
 ## Restrictions
 
-An object of type `binary_semaphore` or `counting_semaphore`, shall not be accessed concurrently by CPU and GPU threads unless:
-  1. it is in managed memory, with `concurrentManagedAccess==1`, or
-  2. it is in host memory, with `hostNativeAtomicSupported==1`.
+An object of type `counting_semaphore` or `binary_semaphore` shall not be
+  accessed concurrently by CPU and GPU threads unless:
+- it is in unified memory and the [`concurrentManagedAccess` property] is 1, or
+- it is in CPU memory and the [`hostNativeAtomicSupported` property] is 1.
 
-This requirement is in addition to the requirement to avoid data-races, see [thread scopes]({{ "./thread_scopes.html" | relative_url }}) for more information.
+Note, for objects of scopes other than `thread_scope_system` this is a
+  data-race, and thefore also prohibited regardless of memory characteristics.
 
-Under Compute Capability 6 or prior, an object of type `binary_semaphore` or `counting_semaphore` may not be used.
+Under CUDA Compute Capability 6 (Pascal) or prior, an object of type
+  `counting_semaphore` or `binary_semaphore` may not be used.
 
 ## Implementation-Defined Behavior
 
-For each scope `S`, the value of `binary_semaphore<S>::max()` is as follows:
+For each [thread scope] `S`, `binary_semaphore<S>::max()` is as follows:
 
-|Scope `S`|`binary_semaphore<S>::max()`|
-|-|-|
-|Any|`1`|
+|Thread Scope `S`|`binary_semaphore<S>::max()`|
+|----------------|----------------------------|
+|Any             |`1`                         |
 
-For each scope `S` and least maximum value `V`, the value of `counting_semaphore<S,V>::max()` is as follows:
+For each [thread scope] `S` and least maximum value `V`,
+  `counting_semaphore<S,V>::max()` is as follows:
 
-|Scope `S`|Least maximum value `V`|`counting_semaphore<S,V>::max()`|
-|-|-|-|
-|Any|Any|`std::numeric_limits<ptrdiff_t>::max()`|
+|Thread Scope `S`|Least Maximum Value `V`|`counting_semaphore<S,V>::max()`  |
+|----------------|-----------------------|----------------------------------|
+|Any             |Any                    |`numeric_limits<ptrdiff_t>::max()`|
 
-Objects in namespace `cuda::std::` have the same behavior as corresponding objects in namespace `cuda::` when instantiated with a scope of `cuda::thread_scope_system`.
+
+[thread scope]: ./thread_scopes.md
+
+[`concurrentManagedAccess` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b
+[`hostNativeAtomicSupported` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f

--- a/docs/api/synchronization_library/thread_scopes.md
+++ b/docs/api/synchronization_library/thread_scopes.md
@@ -1,8 +1,21 @@
+---
+grand_parent: API
+parent: Synchronization Library
+nav_order: 0
+---
+
 # Thread Scopes
 
-Standard C++ presents a view that the cost to synchronize threads is uniform and low. CUDA C++ is different: the overhead is low among threads within a block, and high across arbitrary threads in the system.
+Standard C++ presents a view that the cost to synchronize threads is uniform
+  and low.
+CUDA C++ is different: the overhead is low among threads within a block, and
+  high across arbitrary threads in the system.
 
-To bridge these two realities, libcu++ introduces the concept of thread scopes to the Standard's concurrency facilities in the `cuda::` namespace, while retaining the syntax and semantics of Standard C++ by default.
+To bridge these two realities, libcu++ introduces the concept of **thread scopes**,
+  to the Standard's concurrency facilities in the `cuda::` namespace, while
+  retaining the syntax and semantics of Standard C++ by default.
+A thread scope specifies the group of threads that can synchronize with each
+  other using a concurrency primitive, such as an `atomic` or a `barrier`.
 
 ## Synopsis
 
@@ -21,7 +34,7 @@ class atomic;
 
 void atomic_thread_fence(memory_order, thread_scope = thread_scope_thread);
 
-template<thread_scope Scope = thread_scope_thread, 
+template<thread_scope Scope = thread_scope_thread,
          class Completion = /*implementation-defined*/>
 class barrier;
 
@@ -31,50 +44,106 @@ class latch;
 template<thread_scope Scope = thread_scope_thread>
 class binary_semaphore;
 
-template<thread_scope Scope = thread_scope_thread, 
+template<thread_scope Scope = thread_scope_thread,
          ptrdiff_t LeastMaximum = /*implementation-defined*/>
 class counting_semaphore;
 
 }
 ```
 
-## Scope relationships
+## Scope Relationships
 
-Each program thread is related to each other program thread by one or more thread scope relations:
-1. Each thread (CPU or GPU) is related to each other thread in the computer system by the *system* thread scope, specified with `thread_scope_system`.
-2. Each GPU thread is related to each other GPU thread in the same CUDA device by the *device* thread scope, specified with `thread_scope_device`.
-3. Each GPU thread is related to each other GPU thread in the same CUDA block by the *block* thread scope, specified with `thread_scope_block`.
-4. Each thread (CPU or GPU) is related to itself by the `thread` thread scope, specified with `thread_scope_thread`.
+Each program thread is related to each other program thread by one or more
+  thread scope relations:
+- Each thread (CPU or GPU) is related to each other thread in the computer
+  system by the *system* thread scope, specified with `thread_scope_system`.
+- Each GPU thread is related to each other GPU thread in the same CUDA device
+  by the *device* thread scope, specified with `thread_scope_device`.
+- Each GPU thread is related to each other GPU thread in the same CUDA block
+  by the *block* thread scope, specified with `thread_scope_block`.
+- Each thread (CPU or GPU) is related to itself by the `thread` thread scope,
+  specified with `thread_scope_thread`.
 
-Refer to the CUDA programming guide for more information on how CUDA launches threads into devices and blocks.
+Objects in namespace `cuda::std::` have the same behavior as corresponding
+  objects in namespace `cuda::` when instantiated with a scope of
+  `cuda::thread_scope_system`.
+
+Refer to the [CUDA programming guide] for more information on how CUDA launches
+  threads into devices and blocks.
 
 ## Atomicity
 
 An atomic operation is atomic at the scope it specifies if:
-1. it specifies a scope other than `thread_scope_system`, or
-2. it effects an object in managed memory with `concurrentManagedAccess` is `1`, or***
-3. it effects an object in host memory with `hostNativeAtomicSupported` is `1`, or
-4. it effects an object in peer memory and only GPU threads access it.
+- it specifies a scope other than `thread_scope_system`, or
+- it affects an object in unified memory and [`concurrentManagedAccess`] is
+  `1`, or
+- it affects an object in CPU memory and [`hostNativeAtomicSupported`] is `1`,
+  or
+- it affects an object in GPU peer memory and only GPU threads access it.
 
-Refer to the CUDA programming guide for more information on managed memory, the `concurrentManagedAccess` property, host memory, the `hostNativeAtomicSupported` property, and peer memory.
+Refer to the [CUDA programming guide] for more information on
+  unified memory, CPU memory, and GPU peer memory.
 
-## Data races
+## Data Races
 
-Modify `[intro.races]` paragraph 21 of N4860 as follows:
-> The execution of a program contains a data race if it contains two potentially concurrent conflicting actions, at least one of which is not atomic ***at a scope that includes the thread that performed the other operation***, and neither happens before the other, except for the special case for signal handlers described below. Any such data race results in undefined behavior. [...]
+Modify [intro.races paragraph 21] of ISO/IEC IS 14882 (the C++ Standard) as
+  follows:
+> The execution of a program contains a data race if it contains two
+> potentially concurrent conflicting actions, at least one of which is not
+> atomic
+> ***at a scope that includes the thread that performed the other operation***,
+> and neither happens before the other, except for the special
+> case for signal handlers described below. Any such data race results in
+> undefined behavior. [...]
 
-Modify `[thread.barrier.class]` paragraph 4 of N4860 as follows:
-> 4. Concurrent invocations of the member functions of barrier, other than its destructor, do not introduce data races ***as if they were atomic operations.***. [...]
+Modify [thread.barrier.class paragraph 4] of ISO/IEC IS 14882 (the C++
+  Standard) as follows:
+> 4. Concurrent invocations of the member functions of `barrier`, other than its
+> destructor, do not introduce data races
+> ***as if they were atomic operations***.
+> [...]
 
-Modify `[thread.latch.class]` paragraph 2 of N4860 as follows:
-> 2. Concurrent invocations of the member functions of latch, other than its destructor, do not introduce data races ***as if they were atomic operations.***.
+Modify [thread.latch.class paragraph 2] of ISO/IEC IS 14882 (the C++ Standard)
+  as follows:
+> 2. Concurrent invocations of the member functions of `latch`, other than its
+> destructor, do not introduce data races
+> ***as if they were atomic operations.***.
 
-Modify `[thread.sema.cnt]` paragraph 3 of N4860 as follows:
-> 3. Concurrent invocations of the member functions of counting_semaphore, other than its destructor, do not introduce data races ***as if they were atomic operations.***.
+Modify [thread.sema.cnt paragraph 3] of ISO/IEC IS 14882 (the C++ Standard) as
+  follows:
+> 3. Concurrent invocations of the member functions of `counting_semaphore`,
+> other than its destructor, do not introduce data races
+> ***as if they were atomic operations***.
 
-Modify `[atomics.fences]` paragraphs 2 through 4 of N4860 as follows:
-> A release fence A synchronizes with an acquire fence B if there exist atomic operations X and Y, both operating on some atomic object M, such that A is sequenced before X, X modifies M, Y is sequenced before B, and Y reads the value written by X or a value written by any side effect in the hypothetical release sequence X would head if it were a release operation ***,and each operation (A, B, X, and Y) specifies a scope that includes the thread that performed each other operation***.
+Modify [atomics.fences paragraph 2 through 4] of ISO/IEC IS 14882 (the C++
+  Standard) as follows:
+> A release fence A synchronizes with an acquire fence B if there exist atomic
+> operations X and Y, both operating on some atomic object M, such that A is
+> sequenced before X, X modifies M, Y is sequenced before B, and Y reads the
+> value written by X or a value written by any side effect in the hypothetical
+> release sequence X would head if it were a release operation,
+> ***and each operation (A, B, X, and Y) specifies a scope that includes the thread that performed each other operation***.
 
-> A release fence A synchronizes with an atomic operation B that performs an acquire operation on an atomic object M if there exists an atomic operation X such that A is sequenced before X, X modifies M, and B reads the value written by X or a value written by any side effect in the hypothetical release sequence X would head if it were a release operation ***,and each operation (A, B, and X) specifies a scope that includes the thread that performed each other operation***.
+> A release fence A synchronizes with an atomic operation B that performs an
+> acquire operation on an atomic object M if there exists an atomic operation X
+> such that A is sequenced before X, X modifies M, and B reads the value
+> written by X or a value written by any side effect in the hypothetical
+> release sequence X would head if it were a release operation,
+> ***and each operation (A, B, and X) specifies a scope that includes the thread that performed each other operation***.
 
-> An atomic operation A that is a release operation on an atomic object M synchronizes with an acquire fence B if there exists some atomic operation X on M such that X is sequenced before B and reads the value written by A or a value written by any side effect in the release sequence headed by A ***,and each operation (A, B, and X) specifies a scope that includes the thread that performed each other operation***.
+> An atomic operation A that is a release operation on an atomic object M
+> synchronizes with an acquire fence B if there exists some atomic operation X
+> on M such that X is sequenced before B and reads the value written by A or a
+> value written by any side effect in the release sequence headed by A,
+> ***and each operation (A, B, and X) specifies a scope that includes the thread that performed each other operation***.
+
+
+[intro.races paragraph 21]: https://eel.is/c++draft/intro.races#21
+[thread.barrier.class paragraph 4]: https://eel.is/c++draft/thread.barrier.class#4
+[thread.latch.class paragraph 2]: https://eel.is/c++draft/thread.latch.class#2
+[thread.sema.cnt paragraph 3]: https://eel.is/c++draft/thread.sema.cnt#3
+[atomics.fences paragraph 2 through 4]: https://eel.is/c++draft/atomics.fences#2
+
+[CUDA programming guide]: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
+[`concurrentManagedAccess` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b
+[`hostNativeAtomicSupported` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f

--- a/docs/api/time_library.md
+++ b/docs/api/time_library.md
@@ -1,3 +1,15 @@
+---
+parent: API
+has_children: true
+has_toc: false
+nav_order: 1
+---
+
 # Time Library
+
+Any header not listed below is omitted.
+
+*: Some the Standard C++ facilities in this header are omitted, see the libcu++
+Addendum for details.
 
 {% include_relative time_library/header_table.md %}

--- a/docs/api/time_library/chrono.md
+++ b/docs/api/time_library/chrono.md
@@ -1,3 +1,9 @@
+---
+grand_parent: API
+parent: Time Library
+nav_order: 0
+---
+
 # `<cuda/std/chrono>`
 
 ## Implementation-Defined Behavior
@@ -70,8 +76,8 @@ While our [`std::chrono::high_resolution_clock`] is not heterogeneously steady,
 
 ## Omissions
 
-The following facilities in section ISO/IEC IS 14882 [[time.syn]] of the C++
-  Standard are not available in the NVIDIA C++ Standard Library today:
+The following facilities in section [time.syn] of ISO/IEC IS 14882 (the C++
+  Standard) are not available in the NVIDIA C++ Standard Library today:
 
 - [`std::chrono::steady_clock`] - a monotonically increasing clock.
 - [`std::chrono::duration` I/O operators].

--- a/docs/api/utility_library.md
+++ b/docs/api/utility_library.md
@@ -1,3 +1,15 @@
+---
+parent: API
+has_children: true
+has_toc: false
+nav_order: 2
+---
+
 # Utility Library
+
+Any header not listed below is omitted.
+
+*: Some the Standard C++ facilities in this header are omitted, see the libcu++
+Addendum for details.
 
 {% include_relative utility_library/header_table.md %}

--- a/docs/api/utility_library/functional.md
+++ b/docs/api/utility_library/functional.md
@@ -1,9 +1,15 @@
+---
+grand_parent: API
+parent: Utility Library
+nav_order: 0
+---
+
 # `<cuda/std/functional>`
 
 ## Omissions
 
-The following facilities in section ISO/IEC IS 14882 [[functional.syn]] of the
-  C++ Standard are not available in the NVIDIA C++ Standard Library today:
+The following facilities in section [functional.syn] of ISO/IEC IS 14882 (the
+  C++ Standard) are not available in the NVIDIA C++ Standard Library today:
 
 - [`std::function`] - Polymorphic function object wrapper.
 - [`std::bind`] - Generic function object binder / lambda facility.

--- a/docs/api/utility_library/tuple.md
+++ b/docs/api/utility_library/tuple.md
@@ -1,6 +1,13 @@
+---
+grand_parent: API
+parent: Utility Library
+nav_order: 2
+---
+
 # `<cuda/std/tuple>`
 
 ## Omissions
 
-`tuple` is not available when using NVCC with MSVC as a host compiler.
+`tuple` is not available when using NVCC with MSVC as a host compiler, due to
+  compiler bugs.
 

--- a/docs/api/utility_library/utility.md
+++ b/docs/api/utility_library/utility.md
@@ -1,18 +1,14 @@
+---
+grand_parent: API
+parent: Utility Library
+nav_order: 3
+---
+
 # `<cuda/std/utility>`
-
-## Extensions
-
-TODO (Olivier/Michal): Remove section if not applicable.
-
-## Implementation-Defined Behavior
-
-TODO (Olivier/Michal): Remove section if not applicable.
 
 ## Omissions
 
-TODO (Olivier/Michal): Remove section if not applicable.
-
-## Restrictions
-
-TODO (Olivier/Michal): Remove section if not applicable.
+Only `pair` is available at this time.
+There is no inherent challenge in providing many of the things in `<utility>`;
+  they simply have not been our highest priority.
 

--- a/docs/api/utility_library/version.md
+++ b/docs/api/utility_library/version.md
@@ -1,3 +1,9 @@
+---
+grand_parent: API
+parent: Utility Library
+nav_order: 4
+---
+
 # `<cuda/std/version>`
 
 ## Extensions
@@ -14,12 +20,8 @@ The following version macros, which are explained in the [versioning section],
 
 ## Restrictions
 
-TODO (Michal): Explain what we do about feature test macros, why we don't define
-our own, and why this doesn't interfere with your host standard library.
-
-## Implementation-Defined Behavior
-
-TODO (Olivier/Michal): Remove section if not applicable.
+When using NVCC, the definition of C++ feature test macros is provided by the
+  host Standard Library, not libcu++.
 
 
 [versioning section]: ./api/releases/versioning.md

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,9 @@
+---
+has_children: true
+has_toc: true
+nav_order: 4
+---
+
 # Contributing
 
 We welcome contributions - just send us a pull request!

--- a/docs/contributing/development_model.md
+++ b/docs/contributing/development_model.md
@@ -1,4 +1,0 @@
-# Development Model
-
-TODO: Use Thrust/CUBs as a starting point.
-

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@
 <th><b><a href="https://nvidia.github.io/libcudacxx">Documentation</a></b></th>
 </tr></table>
 
-**libcu++, the NVIDIA C++ Standard Library,  is the C++ Standard Library for
+**libcu++, the NVIDIA C++ Standard Library, is the C++ Standard Library for
   your entire system.**
 It provides a heterogeneous implementation of the C++ Standard Library that can
   be used in and between CPU and GPU code.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,11 +1,18 @@
+---
+has_children: true
+has_toc: true
+nav_order: 3
+---
+
 # Releases
 
 * The latest ABI version is always the default.
 
-| API Version | ABI Version(s)* | Included In                    | Summary |
-|-------------|-----------------|--------------------------------|---------|
-| 1.0.0       | 1               | CUDA Toolkit 10.2              | Atomics, type traits |
-| 1.1.0       | 2               | CUDA Toolkit 11.0 Early Access | Barriers, latches, semaphores |
-| 1.1.1       | 2               | CUDA Toolkit 11.0              | |
+| API Version | ABI Version(s)* | Included In                    | Summary                        |
+|-------------|-----------------|--------------------------------|--------------------------------|
+| 1.0.0       | 1               | CUDA Toolkit 10.2              | Atomics, type traits           |
+| 1.1.0       | 2               | CUDA Toolkit 11.0 Early Access | Barriers, latches, semaphores  |
+| 1.1.1       | 2               | CUDA Toolkit 11.0              |                                |
 | 1.2.0       | 3, 2            | CUDA Toolkit 11.1              | Pipelines, asynchronous copies |
+| 1.3.0       | 3, 2            | CUDA Toolkit 11.2              | Tuples                         |
 

--- a/docs/releases/changelog.md
+++ b/docs/releases/changelog.md
@@ -1,3 +1,8 @@
+---
+parent: Releases
+nav_order: 0
+---
+
 # Changelog
 
 ## libcu++ 1.3.0 (CUDA Toolkit 11.2)

--- a/docs/releases/versioning.md
+++ b/docs/releases/versioning.md
@@ -1,3 +1,8 @@
+---
+parent: Releases
+nav_order: 1
+---
+
 # Versioning
 
 libcu++ is versioned along two axes:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,1 +1,7 @@
+---
+has_children: true
+has_toc: true
+nav_order: 1
+---
+
 # Setup

--- a/docs/setup/building_and_testing.md
+++ b/docs/setup/building_and_testing.md
@@ -1,3 +1,8 @@
+---
+parent: Setup
+nav_order: 2
+---
+
 # Building & Testing libcu++
 
 ## *nix Systems, Native Build/Test

--- a/docs/setup/getting.md
+++ b/docs/setup/getting.md
@@ -1,3 +1,8 @@
+---
+parent: Setup
+nav_order: 1
+---
+
 # Getting libcu++
 
 ## NVIDIA HPC SDK or CUDA Toolkit

--- a/docs/setup/requirements.md
+++ b/docs/setup/requirements.md
@@ -1,3 +1,8 @@
+---
+parent: Setup
+nav_order: 0
+---
+
 # Requirements
 
 All requirements are applicable to the `main` branch on GitHub.


### PR DESCRIPTION
- Shard the Jekyll metadata from `_config.yml` into each of the individual
  markdown files.
- Copy-edit, reformat, and add links to synchronization library documentation.
- Fill in docs for `<utility>`.
- Remove development model section until we get around to it.