### PR TITLE
Add memcpy_async example

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,7 @@
 ---
 has_children: true
 has_toc: true
-nav_order: 4
+nav_order: 5
 ---
 
 # Contributing

--- a/docs/extended_api.md
+++ b/docs/extended_api.md
@@ -1,0 +1,21 @@
+---
+has_children: true
+has_toc: false
+nav_order: 3
+---
+
+# Extended API
+
+## [Headers](./extended_api/headers.md)
+
+### [\<cuda/pipeline\>](./extended_api/headers/pipeline.md)
+
+## [Synchronization library](./extended_api/synchronization_library.md)
+
+### [pipeline](./extended_api/synchronization_library/pipeline.md)
+
+### [pipeline_shared_state](./extended_api/synchronization_library/pipeline_shared_state.md)
+
+## [Asynchronous operations library](./extended_api/asynchronous_operations_library.md)
+
+### [memcpy_async](./extended_api/asynchronous_operations_library/memcpy_async.md)

--- a/docs/extended_api/asynchronous_operations_library.md
+++ b/docs/extended_api/asynchronous_operations_library.md
@@ -1,0 +1,13 @@
+---
+parent: Extended API
+has_children: true
+has_toc: false
+---
+
+# Asynchronous operations library
+
+The asynchronous operations library provides components for asynchronous data movement.
+
+## Asynchronous operations
+
+| [memcpy_async](./asynchronous_operations_library/memcpy_async.md) | asynchronously copies one buffer to another `(function template)` |

--- a/docs/extended_api/asynchronous_operations_library/aligned_size_t.md
+++ b/docs/extended_api/asynchronous_operations_library/aligned_size_t.md
@@ -1,0 +1,59 @@
+---
+grand_parent: Extended API
+parent: Asynchronous operations library
+---
+
+# cuda::**aligned_size_t**
+
+Defined in header [`<cuda/barrier>`](../headers/barrier.md)
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+template<std::size_t Alignment>
+struct aligned_size_t;
+```
+
+The class template `cuda::aligned_size_t` is a _shape_ representing an extent of bytes with a statically defined (address and size) alignment.
+
+## Template parameters
+
+| Alignment | the address & size alignement of the byte extent |
+
+## Data members
+
+| [align](./aligned_size_t/align.md) | the alignment of the byte extent |
+| [value](./aligned_size_t/value.md) | the size of the byte extent      |
+
+## Member functions
+
+| [(constructor)](./aligned_size_t/constructor.md) | constructs an _aligned size_                                                           |
+| (destructor) [implicitly declared]               | trivial implicit destructor                                                            |
+| operator= [implicitly declared]                  | trivial implicit copy/move assignment                                                  |
+| operator std::size_t                             | implicit conversion to [`std::size_t`](https://en.cppreference.com/w/cpp/types/size_t) |
+
+## Notes
+
+If `value` is not a multiple of `align` the behavior is undefined.
+
+If `Alignment` is not a [valid alignment](https://en.cppreference.com/w/c/language/object#Alignment) the behavior is undefined.
+
+## Example
+
+```c++
+#include <cuda/barrier>
+
+__global__ void example_kernel(void * dst, void * src, size_t size)
+{
+    cuda::barrier<cuda::thread_scope_system> barrier;
+    init(&barrier, 1);
+
+    // Implementation cannot make assumptions about alignment
+    cuda::memcpy_async(dst, src, size, barrier);
+
+    // Implementation can assume that dst, src and size are 16-bytes aligned and may optimize accordingly
+    cuda::memcpy_async(dst, src, cuda::aligned_size_t<16>(size), barrier);
+
+    barrier.arrive_and_wait();
+}
+```

--- a/docs/extended_api/asynchronous_operations_library/aligned_size_t/align.md
+++ b/docs/extended_api/asynchronous_operations_library/aligned_size_t/align.md
@@ -1,0 +1,11 @@
+---
+nav_exclude: true
+---
+
+# cuda::aligned_size_t\<Alignment>::**align**
+
+```c++
+static constexpr std::size_t align = Alignment;
+```
+
+Represents the alignment (address and size) of the byte extent.

--- a/docs/extended_api/asynchronous_operations_library/aligned_size_t/constructor.md
+++ b/docs/extended_api/asynchronous_operations_library/aligned_size_t/constructor.md
@@ -1,0 +1,15 @@
+---
+nav_exclude: true
+---
+
+# cuda::aligned_size_t\<Alignment>::**aligned_size_t**
+
+```c++
+explicit aligned_size_t(size_t size);
+```
+
+Constructs an `aligned_size_t` _shape_.
+
+## Notes
+
+If `size` is not a multiple of `Alignment` the behavior is undefined.

--- a/docs/extended_api/asynchronous_operations_library/aligned_size_t/value.md
+++ b/docs/extended_api/asynchronous_operations_library/aligned_size_t/value.md
@@ -1,0 +1,11 @@
+---
+nav_exclude: true
+---
+
+# cuda::aligned_size_t\<Alignment>::**value**
+
+```c++
+std::size_t value;
+```
+
+Represents the size of the byte extent.

--- a/docs/extended_api/asynchronous_operations_library/memcpy_async.md
+++ b/docs/extended_api/asynchronous_operations_library/memcpy_async.md
@@ -1,0 +1,60 @@
+---
+grand_parent: Extended API
+parent: Asynchronous operations library
+---
+
+# cuda::**memcpy_async**
+
+Defined in header [`<cuda/barrier>`](../../api/synchronization_library/barrier.md)
+
+```c++
+template<typename Size, thread_scope Scope>
+void memcpy_async(void * destination, void const * source, Size size, barrier<Scope> & barrier);                        // (1)
+
+template<typename Group, typename Size, thread_scope Scope>
+void memcpy_async(Group const & group, void * destination, void const * source, Size size, barrier<Scope> & barrier);   // (2)
+```
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+template<typename Size, thread_scope Scope>
+void memcpy_async(void * destination, void const * source, Size size, pipeline<Scope> & pipeline);                      // (3)
+
+template<typename Group, typename Size, thread_scope Scope>
+void memcpy_async(Group const & group, void * destination, void const * source, Size size, pipeline<Scope> & pipeline); // (4)
+```
+
+Asynchronously copies `size` bytes from the memory location pointed to by `source` to the memory location pointed to by `destination`.
+Both objects are reinterpreted as arrays of `unsigned char`.
+
+`cuda::memcpy_async` have similar constraints to [`std::memcpy`](https://en.cppreference.com/w/cpp/string/byte/memcpy), namely:
+* If the objects overlap, the behavior is undefined.
+* If either `destination` or `source` is an invalid or null pointer, the behavior is undefined (even if `count` is zero).
+* If the objects are potentially-overlapping or not [`TriviallyCopyable`](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable),
+  the behavior is undefined.
+
+1. Binds the asynchronous copy completion to `barrier` and issues the copy in the current thread.
+2. Binds the asynchronous copy completion to `barrier` and cooperatively issues the copy across all threads in `group`.
+3. Binds the asynchronous copy completion to `pipeline` and issues the copy in the current thread
+4. Binds the asynchronous copy completion to `pipeline` and cooperatively issues the copy across all threads in `group`.
+
+## Template parameters
+
+| Group | a type satisfying the [_group concept_](http://LINK-TODO)                                                 |
+| Size  | [`size_t`](https://en.cppreference.com/w/c/types/size_t) or [`cuda::aligned_size_t`](./aligned_size_t.md) |
+
+## Parameters
+
+| group       | the group of threads                                    |
+| destination | pointer to the memory location to copy to               |
+| source      | pointer to the memory location to copy from             |
+| size        | the number of bytes to copy                             |
+| barrier     | the barrier object used to wait on the copy completion  |
+| pipeline    | the pipeline object used to wait on the copy completion |
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/asynchronous_operations_library/memcpy_async.md
+++ b/docs/extended_api/asynchronous_operations_library/memcpy_async.md
@@ -55,6 +55,73 @@ Both objects are reinterpreted as arrays of `unsigned char`.
 
 ## Example
 
+CUDA kernels often first copy data from global to shared memory, to then perform a computation using that shared memory data:
+
 ```c++
-TODO
+#include <cooperative_groups.h>
+__device__ void compute(float*);
+
+__global__ void kernel(float* global, size_t subset_count) {
+  extern __shared__ float shared[];
+  auto group = cooperative_groups::this_thread_block();
+  size_t shared_idx = group.thread_rank();
+
+  for (size_t subset = 0; subset < subset_count; ++subset) {
+    size_t global_idx = subset * group.size() + group.thread_rank();
+    shared[shared_idx] = global[global_idx];  // Fetch from global to shared
+    group.sync();                             // Wait for copy to complete
+    compute(shared);                          // Compute
+    group.sync();                             // Wait for compute to complete
+  }
+}
+```
+
+With `cuda::memcpy_async` we can overlap the global to shared memory copies of the next batch, with the computation on the current batch, by using a two-stage pipeline as follows: 
+
+```c++
+#include <cooperative_groups.h>
+#include <cuda/pipeline>
+__device__ void compute(float*);
+
+__global__ void kernel(float* global, size_t subset_count) {
+  auto group = cooperative_groups::this_thread_block();
+
+  constexpr unsigned stages_count = 2;
+  extern __shared__ float s[];
+  // Two batches must fit in shared memory, pointers to each batch:
+  float * shared[stages_count] = { s, s + group.size() };
+ 
+  // Allocate shared storage for a two-stage cuda::pipeline:
+  __shared__ cuda::pipeline_shared_state<
+    cuda::thread_scope::thread_scope_block,
+    stages_count
+  > shared_state;
+  auto pipeline = cuda::make_pipeline(group, &shared_state);
+ 
+  for (size_t subset = 0, fetch = 0; subset < subset_count; ++subset) {
+    size_t stage_idx = fetch % 2; 
+    // Fetche up to `stages_count` subsets ahead:
+    for (; fetch < subset_count && fetch < (subset + stages_count); ++fetch ) {
+      // Collectively acquire the pipeline head stage from all producer threads:
+      pipeline.producer_acquire();
+      size_t global_idx = (subset + 1) * group.size();
+      cuda::memcpy_async(  // Submit async copies to the pipeline's head stage
+        group,
+        shared[stage_idx],
+        &global[global_idx],
+        sizeof(float) * group.size(),
+        pipeline
+      );
+      // Collectively commit (advance) the pipeline's head stage
+      pipeline.producer_commit(); 
+    }
+    // Collectively wait for the operations commited to the
+    // current `subset` stage to complete:
+    pipeline.consumer_wait(); 
+    compute(shared[stage_idx]);
+    
+    // Collectively release the stage resources
+    pipeline.consumer_release();
+  }
+}
 ```

--- a/docs/extended_api/asynchronous_operations_library/memcpy_async.md
+++ b/docs/extended_api/asynchronous_operations_library/memcpy_async.md
@@ -55,7 +55,7 @@ Both objects are reinterpreted as arrays of `unsigned char`.
 
 ## Example
 
-CUDA kernels often first copy data from global to shared memory, to then perform a computation using that shared memory data:
+CUDA kernels often first copy data from global to shared memory, to then perform a computation using that shared memory data ([live](https://cuda.godbolt.org/z/34PMMe)):
 
 ```c++
 #include <cooperative_groups.h>
@@ -76,7 +76,7 @@ __global__ void kernel(float* global, size_t subset_count) {
 }
 ```
 
-With `cuda::memcpy_async` we can overlap the global to shared memory copies of the next batch, with the computation on the current batch, by using a two-stage pipeline as follows: 
+With `cuda::memcpy_async` we can overlap the global to shared memory copies of the next batch, with the computation on the current batch, by using a two-stage pipeline as follows ([live](https://cuda.godbolt.org/z/GMGe8P)):
 
 ```c++
 #include <cooperative_groups.h>

--- a/docs/extended_api/headers.md
+++ b/docs/extended_api/headers.md
@@ -1,0 +1,12 @@
+---
+parent: Extended API
+has_children: true
+has_toc: false
+nav_order: 0
+---
+
+# Headers
+
+## Synchronization library
+
+| [\<pipeline\>](./headers/pipeline.md) | [Pipelines](./synchronization_library/pipeline.md) and corresponding [memcpy_async](./asynchronous_operations_library/memcpy_async.md) overloads |

--- a/docs/extended_api/headers/pipeline.md
+++ b/docs/extended_api/headers/pipeline.md
@@ -1,0 +1,101 @@
+---
+grand_parent: Extended API
+parent: Headers
+---
+
+# \<cuda/**pipeline**>
+
+This header is part of the [synchronization library](../synchronization_library.md).
+
+## Classes
+
+| [pipeline](../synchronization_library/pipeline/pipeline.md)                           | _pipeline_ class template `(class template)`                                       |
+| [pipeline_shared_state](../synchronization_library/pipeline/pipeline_shared_state.md) | _pipeline shared state_ for inter-thread coordination `(class template)`           |
+| [pipeline_role](../synchronization_library/pipeline/pipeline_role.md)                 | defines producer/consumer role for a thread participating in a _pipeline_ `(enum)` |
+
+## Functions
+
+| [make_pipeline](../synchronization_library/pipeline/make_pipeline.md)                               | creates a _pipeline_ object                                                                      |
+| [pipeline_consumer_wait_prior](../synchronization_library/pipeline/pipeline_consumer_wait_prior.md) | blocks the current thread until all operations committed up to a prior _pipeline stage_ complete |
+| [pipeline_producer_commit](./synchronization_library/pipeline_consumer_commit.md)                   | Binds operations previously issued by the current thread to a _barrier_                          |
+
+## Synopsis
+
+```c++
+namespace cuda {
+    enum pipeline_role : /* unspecified */ {
+        producer,
+        consumer
+    };
+
+    template<thread_scope Scope, uint8_t StagesCount>
+    class pipeline_shared_state;
+
+    template<thread_scope Scope>
+    class pipeline;
+
+    pipeline<thread_scope_thread> make_pipeline();
+
+    template<class Group, thread_scope Scope, uint8_t StagesCount>
+    pipeline<Scope> make_pipeline(const Group & group, pipeline_shared_state<Scope, StagesCount> * shared_state);
+
+    template<class Group, thread_scope Scope, uint8_t StagesCount>
+    pipeline<Scope> make_pipeline(const Group & group, pipeline_shared_state<Scope, StagesCount> * shared_state, size_t producer_count);
+
+    template<class Group, thread_scope Scope, uint8_t StagesCount>
+    pipeline<Scope> make_pipeline(const Group & group, pipeline_shared_state<Scope, StagesCount> * shared_state, pipeline_role role);
+
+    template<uint8_t Prior>
+    void pipeline_consumer_wait_prior(pipeline<thread_scope_thread> & pipeline);
+
+    template<thread_scope Scope>
+    void pipeline_producer_commit(pipeline<thread_scope_thread> & pipeline, barrier<Scope> & barrier);
+
+    template<typename Group, typename Size, thread_scope Scope>
+    void memcpy_async(Group const & group, void * destination, void const * source, Size size, pipeline<Scope> & pipeline);
+
+    template<typename Size, thread_scope Scope>
+    void memcpy_async(void * destination, void const * source, Size size, pipeline<Scope> & pipeline);
+}
+```
+
+## Class template `cuda::pipeline_shared_state`
+
+```c++
+namespace cuda {
+    template<thread_scope Scope, uint8_t StagesCount>
+    class pipeline_shared_state {
+        pipeline_shared_state() = default;
+        pipeline_shared_state(const pipeline_shared_state &) = delete;
+        pipeline_shared_state(pipeline_shared_state &&) = delete;
+        pipeline_shared_state & operator=(pipeline_shared_state &&) = delete;
+        pipeline_shared_state & operator=(const pipeline_shared_state &) =  delete;
+    };
+}
+```
+
+## Class template `cuda::pipeline`
+
+```c++
+namespace cuda {
+    template<thread_scope Scope>
+    class pipeline {
+        pipeline(pipeline &&) = default;
+        pipeline(const pipeline &) = delete;
+        pipeline & operator=(pipeline &&) = delete;
+        pipeline & operator=(const pipeline &) = delete;
+        ~pipeline();
+
+        void producer_acquire();
+        void producer_commit();
+        void consumer_wait();
+        template<class Rep, class Period>
+        bool consumer_wait_for(const std::chrono::duration<Rep, Period> & duration);
+        template<class Clock, class Duration>
+        bool consumer_wait_until(const std::chrono::time_point<Clock, Duration> & time_point);
+        void consumer_release();
+
+        bool quit();
+    };
+}
+```

--- a/docs/extended_api/synchronization_library.md
+++ b/docs/extended_api/synchronization_library.md
@@ -1,0 +1,24 @@
+---
+parent: Extended API
+has_children: true
+has_toc: false
+---
+
+# Synchronization library
+
+The synchronization library provides components for thread and asynchronous operations coordination.
+
+## Synchronization types
+
+| [pipeline](./synchronization_library/pipeline.md)                           | _pipeline_ class template `(class template)`                                       |
+| [pipeline_shared_state](./synchronization_library/pipeline_shared_state.md) | _pipeline shared state_ for inter-thread coordination `(class template)`           |
+| [pipeline_role](./synchronization_library/pipeline_role.md)                 | defines producer/consumer role for a thread participating in a _pipeline_ `(enum)` |
+
+## Synchronization types factories
+
+| [make_pipeline](./synchronization_library/make_pipeline.md) | creates a _pipeline_ object `(function template)` |
+
+## Operations on synchronization types
+
+| [pipeline_consumer_wait_prior](./synchronization_library/pipeline_consumer_wait_prior.md) | blocks the current thread until all operations committed up to a prior _pipeline stage_ complete `(function template)`|
+| [pipeline_producer_commit](./synchronization_library/pipeline_consumer_commit.md)         | Binds operations previously issued by the current thread to a _barrier_ `(function template)`                         |

--- a/docs/extended_api/synchronization_library/make_pipeline.md
+++ b/docs/extended_api/synchronization_library/make_pipeline.md
@@ -1,0 +1,56 @@
+---
+grand_parent: Extended API
+parent: Synchronization library
+---
+
+# cuda::**make_pipeline**
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+pipeline<thread_scope_thread> make_pipeline();                                                                                       // (1)
+
+template<class Group, thread_scope Scope, uint8_t StagesCount>
+pipeline<Scope> make_pipeline(const Group & group, pipeline_shared_state<Scope, StagesCount> * shared_state);                        // (2)
+
+template<class Group, thread_scope Scope, uint8_t StagesCount>
+pipeline<Scope> make_pipeline(const Group & group, pipeline_shared_state<Scope, StagesCount> * shared_state, size_t producer_count); // (3)
+
+template<class Group, thread_scope Scope, uint8_t StagesCount>
+pipeline<Scope> make_pipeline(const Group & group, pipeline_shared_state<Scope, StagesCount> * shared_state, pipeline_role role);    // (4)
+```
+
+1. Creates a _unified pipeline_ such that the calling thread is the only participating thread and performs both producer and consumer actions.
+2. Creates a _unified pipeline_ such that all the threads in `group` are performing both producer and consumer actions.
+3. Creates a _partitioned pipeline_ such that `producer_threads` number of threads in `group` are performing producer actions while the others
+   are performing consumer actions. 
+4. Creates a _partitioned pipeline_ where each thread's role is explicitly specified.
+
+All threads in `group` acquire collective ownership of the `shared_state` storage.
+
+`make_pipeline` must be invoked by every threads in `group` such that `group::sync` may be invoked.
+
+`shared_state` and `producer_count` must be uniform across all threads in `group`, else the behavior is undefined.
+
+`producer_count` must be strictly inferior to `group::size`, else the behavior is undefined.
+
+## Template parameters
+
+| Group | a type satisfying the [_group concept_](http://LINK-TODO) |
+
+## Parameters
+
+| group          | the group of threads                                                                                                                   |
+| shared_state   | an object of type [`cuda::pipeline_shared_state<Scope>`](./pipeline_shared_state.md) with `Scope` including all the threads in `group` |
+| producer_count | the number of _producer threads_ in the pipeline                                                                                       |
+| role           | the role of the current thread in the pipeline                                                                                         |
+
+## Return value
+
+A thread-local `cuda::pipeline` object.
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline.md
+++ b/docs/extended_api/synchronization_library/pipeline.md
@@ -1,0 +1,56 @@
+---
+grand_parent: Extended API
+parent: Synchronization library
+---
+
+# cuda::**pipeline**
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+template<cuda::thread_scope Scope>
+class pipeline;
+```
+
+The class template `cuda::pipeline` provides a coordination mechanism allowing to pipeline multiple operations in a sequence of stages.
+
+A thread interacts with a _pipeline stage_ using the following pattern:
+1. Acquire the pipeline stage
+2. Commit some operations to the stage
+3. Wait for the previously committed operations to complete
+4. Release the pipeline stage
+
+For thread scopes other than `thread_scope_thread`, a [`pipeline_shared_state`](./pipeline_shared_state.md) is required to coordinate the participating threads.
+
+_Pipelines_ can be either _unified_ or _partitioned_.
+In a _unified pipeline_, all the participating threads are both producers and consumers.
+In a _partitioned pipeline_, each participating thread is either a producer or (exclusive) a consumer.
+
+## Template parameters
+
+### Scope
+
+A [`cuda::thread_scope`](../../api/synchronization_library/thread_scopes.md) denoting a scope including all the threads participating in the _pipeline_.
+
+## Member functions
+
+| (constructor) [deleted]                            | `pipeline` is not constructible                                                                                                                  |
+| [(destructor)](./pipeline/destructor.md)           | destroys the `pipeline`                                                                                                                          |
+| operator= [deleted]                                | `pipeline` is not assignable                                                                                                                     |
+| [producer_acquire](./pipeline/producer_acquire.md) | blocks the current thread until the next _pipeline stage_ is available                                                                           |
+| [producer_commit](./pipeline/producer_commit.md)   | commits operations previously issued by the current thread to the current _pipeline stage_                                                       |
+| [consumer_wait](./pipeline/consumer_wait.md)       | blocks the current thread until all operations committed to the current _pipeline stage_ complete                                                |
+| [consumer_wait_for](./pipeline/consumer_wait.md)   | blocks the current thread until all operations committed to the current _pipeline stage_ complete or after the specified timeout duration        |
+| [consumer_wait_until](./pipeline/consumer_wait.md) | blocks the current thread until all operations committed to the current _pipeline stage_ complete or until specified time point has been reached |
+| [consumer_release](./pipeline/consumer_release.md) | release the current _pipeline stage_                                                                                                             |
+| [quit](./pipeline/quit.md)                         | quits current thread's participation in the _pipeline_                                                                                           |
+
+## Notes
+
+A thread role cannot change during the lifetime of the pipeline object.
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline/consumer_release.md
+++ b/docs/extended_api/synchronization_library/pipeline/consumer_release.md
@@ -1,0 +1,15 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline\<Scope>::**consumer_release**
+
+```c++
+void consumer_release();
+```
+
+Releases the current _pipeline stage_.
+
+## Notes
+
+Calling this method from a _producer thread_ is undefined behavior.

--- a/docs/extended_api/synchronization_library/pipeline/consumer_wait.md
+++ b/docs/extended_api/synchronization_library/pipeline/consumer_wait.md
@@ -1,0 +1,38 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline\<Scope>::**consumer_wait**, cuda::pipeline\<Scope>::**consumer_wait_for**, cuda::pipeline\<Scope>::**consumer_wait_until**
+
+```c++
+void consumer_wait();                                                                  // (1)
+
+template<class Rep, class Period>
+bool consumer_wait_for(const std::chrono::duration<Rep, Period> & duration);           // (2)
+
+template<class Clock, class Duration>
+bool consumer_wait_until(const std::chrono::time_point<Clock, Duration> & time_point); // (3)
+```
+
+1. blocks the current thread until all operations committed to the current _pipeline stage_ complete
+2. blocks the current thread until all operations committed to the current _pipeline stage_ complete or after the specified timeout duration
+3. blocks the current thread until all operations committed to the current _pipeline stage_ complete or until specified time point has been reached
+
+## Parameters
+
+| duration   | an object of type `cuda::std::chrono::duration` representing the maximum time to spend waiting |
+| time_point | an object of type `cuda::std::chrono::time_point` representing the time when to stop waiting   |
+
+## Return value
+
+`false` if the _wait_ timed out, `true` otherwise.
+
+## Notes
+
+Calling this method from a _producer thread_ is undefined behavior.
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline/destructor.md
+++ b/docs/extended_api/synchronization_library/pipeline/destructor.md
@@ -1,0 +1,21 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline\<Scope>::**~pipeline**
+
+```c++
+~pipeline();
+```
+
+Destructs the pipeline.
+
+## Notes
+
+Calls [`cuda::pipeline<scope>::quit`](./quit.md) if it was not called by the current thread.
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline/producer_acquire.md
+++ b/docs/extended_api/synchronization_library/pipeline/producer_acquire.md
@@ -1,0 +1,15 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline\<Scope>::**producer_acquire**
+
+```c++
+void producer_acquire();
+```
+
+Blocks the current thread until the next _pipeline stage_ is available.
+
+## Notes
+
+Calling this method from a _consumer thread_ is undefined behavior.

--- a/docs/extended_api/synchronization_library/pipeline/producer_commit.md
+++ b/docs/extended_api/synchronization_library/pipeline/producer_commit.md
@@ -1,0 +1,15 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline\<Scope>::**producer_commit**
+
+```c++
+void producer_commit();
+```
+
+Commits operations previously issued by the current thread to the current _pipeline stage_.
+
+## Notes
+
+Calling this method from a _consumer thread_ is undefined behavior.

--- a/docs/extended_api/synchronization_library/pipeline/quit.md
+++ b/docs/extended_api/synchronization_library/pipeline/quit.md
@@ -1,0 +1,25 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline\<Scope>::**quit**
+
+```c++
+bool quit();
+```
+
+Quits the current thread's participation in the collective ownership of the corresponding _shared state_ ([`cuda::pipeline_shared_state`](../pipeline_shared_state.md)). Ownership of the _shared state_ is released by the last invoking thread.
+
+## Return value
+
+`true` if ownership of the _shared state_ was released, otherwise `false`.
+
+## Notes
+
+The behavior undefined if any operation other than [`~pipeline`](./destructor.md) is issued by the current thread after quitting.
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline_consumer_wait_prior.md
+++ b/docs/extended_api/synchronization_library/pipeline_consumer_wait_prior.md
@@ -1,0 +1,30 @@
+---
+grand_parent: Extended API
+parent: Synchronization library
+---
+
+# cuda::**pipeline_consumer_wait_prior**
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+template<uint8_t Prior>
+void pipeline_consumer_wait_prior(pipeline<thread_scope_thread> & pipeline);
+```
+
+Blocks the current thread until all operations committed to _pipelines stages_ sequenced before the `Prior` last one complete. All stages up to `Prior` (excluded)
+are implicitly released.
+
+## Template parameters
+
+| Prior | The Nth latest stage to wait for |
+
+## Parameters
+
+| pipeline | the thread-scoped `cuda::pipeline` object to wait on |
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline_producer_commit.md
+++ b/docs/extended_api/synchronization_library/pipeline_producer_commit.md
@@ -1,0 +1,25 @@
+---
+grand_parent: Extended API
+parent: Synchronization library
+---
+
+# cuda::**pipeline_producer_commit**
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+template<thread_scope Scope>
+void pipeline_producer_commit(pipeline<thread_scope_thread> & pipeline, barrier<Scope> & barrier);
+```
+
+Binds operations previously issued by the current thread to the named `barrier` such that a `barrier::arrive` is performed on completion. The bind operation implicitly increments the barrier's current phase to account for the subsequent `barrier::arrive`, resulting in a net change of 0.
+
+## Parameters
+
+| pipeline | the thread-scoped `cuda::pipeline` object to wait on |
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline_role.md
+++ b/docs/extended_api/synchronization_library/pipeline_role.md
@@ -1,0 +1,27 @@
+---
+grand_parent: Extended API
+parent: Synchronization library
+---
+
+# cuda::**pipeline_role**
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+enum pipeline_role : /* unspecified */ {
+    producer,
+    consumer
+};
+```
+`cuda::pipeline_role` specifies the role of a particular thread in a partitioned producer/consumer pipeline.
+
+## Constants
+
+| producer | a producer thread generates data (e.g. by issuing [`memcpy_async`](../asynchronous_operations_library/memcpy_async.md) operations)                           |
+| consumer | a consumer thread consumes data (e.g. by waiting for previously [`memcpy_async`](../asynchronous_operations_library/memcpy_async.md) operations to complete) |
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/extended_api/synchronization_library/pipeline_shared_state.md
+++ b/docs/extended_api/synchronization_library/pipeline_shared_state.md
@@ -1,0 +1,47 @@
+---
+grand_parent: Extended API
+parent: Synchronization library
+---
+
+# cuda::**pipeline_shared_state**
+
+Defined in header [`<cuda/pipeline>`](../headers/pipeline.md)
+
+```c++
+template<cuda::thread_scope Scope, uint8_t StagesCount>
+class pipeline_shared_state;
+```
+
+The class template `cuda::pipeline_shared_state` is a storage type used to coordinate the threads participating in a `cuda::pipeline`.
+
+## Template parameters
+
+| Scope       | A [`cuda::thread_scope`](../../api/synchronization_library/thread_scopes.md) denoting a scope including all the threads participating in the `cuda::pipeline`. `Scope` cannot be `thread_scope_thread`.|
+| StagesCount | The number of stages for the _pipeline_.                                                                                                                                                               |
+
+## Member functions
+
+| [(constructor)](./pipeline_shared_state/constructor.md) | constructs a `pipeline_shared_state`      |
+| [(destructor)](./pipeline_shared_state/destructor.md)   | destroys the `pipeline_shared_state`      |
+| operator= [deleted]                                     | `pipeline_shared_state` is not assignable |
+
+## Example
+
+```c++
+#include <cuda/pipeline>
+
+__global__ void example_kernel(char * device_buffer, char * sysmem_buffer)
+{
+    // Allocate a 2 stage block scoped shared state in shared memory
+    __shared__ cuda::pipeline_shared_state<cuda::thread_scope::thread_scope_block, 2> pss_1;
+
+    // Allocate a 2 stage block scoped shared state in device memory
+    auto * pss_2 = new cuda::pipeline_shared_state<cuda::thread_scope::thread_scope_block, 2>;
+
+    // Construct a 2 stage device scoped shared state in device memory
+    auto * pss_3 = new(device_buffer) cuda::pipeline_shared_state<cuda::thread_scope::thread_scope_device, 2>;
+
+    // Construct a 2 stage system scoped shared state in system memory
+    auto * pss_4 = new(sysmem_buffer) cuda::pipeline_shared_state<cuda::thread_scope::thread_scope_system, 2>;
+}
+```

--- a/docs/extended_api/synchronization_library/pipeline_shared_state/constructor.md
+++ b/docs/extended_api/synchronization_library/pipeline_shared_state/constructor.md
@@ -1,0 +1,38 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline_shared_state\<Scope, StagesCount>::**pipeline_shared_state**
+
+```c++
+pipeline_shared_state();                                       // (1)
+pipeline_shared_state(const pipeline_shared_state &) = delete; // (2)
+pipeline_shared_state(pipeline_shared_state &&) = delete;      // (3)
+```
+
+1. Constructs the pipeline shared state.
+2. Copy constructor is deleted.
+3. Move constructor is deleted.
+
+## Notes
+
+Static declaration of `pipeline_shared_state` within device code currently emits the following warning:
+
+```
+warning: dynamic initialization is not supported for a function-scope static __shared__ variable within a __device__/__global__ function
+```
+
+It can be silenced using `#pragma diag_suppress static_var_with_dynamic_init`.
+
+## Example
+
+```c++
+#include <cuda/pipeline>
+
+#pragma diag_suppress static_var_with_dynamic_init
+
+__global__ void example_kernel()
+{
+    __shared__ cuda::pipeline_shared_state<cuda::thread, 2> shared_state;
+}
+```

--- a/docs/extended_api/synchronization_library/pipeline_shared_state/destructor.md
+++ b/docs/extended_api/synchronization_library/pipeline_shared_state/destructor.md
@@ -1,0 +1,17 @@
+---
+nav_exclude: true
+---
+
+# cuda::pipeline_shared_state\<Scope, StagesCount>::**~pipeline_shared_state**
+
+```c++
+~pipeline_shared_state();
+```
+
+Destructs the pipeline shared state.
+
+## Example
+
+```c++
+TODO
+```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,7 +1,7 @@
 ---
 has_children: true
 has_toc: true
-nav_order: 3
+nav_order: 4
 ---
 
 # Releases


### PR DESCRIPTION
This PR adds an example for the `cuda::memcpy_async` API adapted from [this blogpost](https://developer.nvidia.com/blog/controlling-data-movement-to-boost-performance-on-ampere-architecture/).

[Rendered documentation](https://github.com/gonzalobg/libcudacxx/blob/docs/extended-api-examples/docs/extended_api/asynchronous_operations_library/memcpy_async.md#example).

cc @c0riolis 