### PR TITLE
Enable `is_constant_evaluated` in c++11

### DIFF
--- a/.upstream-tests/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.fail.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.fail.cpp
@@ -19,7 +19,7 @@
 
 int main(int, char**)
 {
-#ifndef __cpp_lib_is_constant_evaluated
+#ifndef _LIBCUDACXX_IS_CONSTANT_EVALUATED
   // expected-error@+1 {{no member named 'is_constant_evaluated' in namespace 'std'}}
   bool b = cuda::std::is_constant_evaluated();
 #else

--- a/.upstream-tests/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.const.eval/is_constant_evaluated.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03
 
 // <cuda/std/type_traits>
 
@@ -17,17 +17,20 @@
 
 #include "test_macros.h"
 
+// libcudacxx does not have feature test macros... yet
+/*
 #ifndef __cpp_lib_is_constant_evaluated
 #if TEST_HAS_BUILTIN(__builtin_is_constant_evaluated)
 # error __cpp_lib_is_constant_evaluated should be defined
 #endif
 #endif
+*/
 
 template <bool> struct InTemplate {};
 
 int main(int, char**)
 {
-#ifdef __cpp_lib_is_constant_evaluated
+#if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
   // Test the signature
   {
     ASSERT_SAME_TYPE(decltype(cuda::std::is_constant_evaluated()), bool);

--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -1562,7 +1562,7 @@ struct is_nothrow_convertible : _Or<
 template <typename _Fm, typename _To>
 _LIBCUDACXX_INLINE_VAR constexpr bool is_nothrow_convertible_v = is_nothrow_convertible<_Fm, _To>::value;
 
-#endif // _LIBCUDACXX_STD_VER > 11 
+#endif // _LIBCUDACXX_STD_VER > 11
 
 // is_empty
 
@@ -4824,7 +4824,7 @@ struct __can_extract_map_key<_ValTy, _Key, _Key, _RawValTy>
 #endif
 
 #if defined(_LIBCUDACXX_IS_CONSTANT_EVALUATED)
-#if _LIBCUDACXX_STD_VER > 17
+#if (defined(__cuda_std__) && _LIBCUDACXX_STD_VER >= 11) || _LIBCUDACXX_STD_VER > 17
 _LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr bool is_constant_evaluated() noexcept {
   return _LIBCUDACXX_IS_CONSTANT_EVALUATED();


### PR DESCRIPTION
This seems acceptable to backport and will be useful for constexpr `<complex>`.

We test on the builtin being available, however, in some compiler versions it won't be depending on host+NVCC combination. 

We should also look into exposing feature test macros with some mechanism similar to `<version>`