### PR TITLE
Use explicit form of common_type_t to work around CUDA 10.1 nvcc issue

### DIFF
--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -3096,7 +3096,7 @@ class hh_mm_ss
 {
 private:
     static_assert(__is_duration<_Duration>::value, "template parameter of hh_mm_ss must be a std::chrono::duration");
-    using __CommonType = common_type_t<_Duration, chrono::seconds>;
+    using __CommonType = typename common_type<_Duration, chrono::seconds>::type;
 
     _LIBCUDACXX_INLINE_VISIBILITY
     static constexpr uint64_t __pow10(unsigned __exp)


### PR DESCRIPTION
Fixes issue compiling with CUDA 10.1 nvcc ([example here](https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fcudf%2Fprb%2Fcudf-gpu-build/detail/cudf-gpu-build/36990/pipeline#log-1360)).

<details><summary>Click to expand stack trace</summary>
<pre >
cuda/std/detail/libcxx/include/chrono:3121:60: error: expansion pattern ‘_Duration’ contains no argument packs
     using precision = duration&lt;typename __CommonType::rep, ratio&lt;1, __pow10(fractional_width)&gt;&gt;;
                                                            ^~~
cuda/std/detail/libcxx/include/chrono:3121:99: error: template argument 1 is invalid
     using precision = duration&lt;typename __CommonType::rep, ratio&lt;1, __pow10(fractional_width)&gt;&gt;;
cuda/std/detail/libcxx/include/chrono:3121:107: error: expected template-argument before ‘::’ token
     using precision = duration&lt;typename __CommonType::rep, ratio&lt;1, __pow10(fractional_width)&gt;&gt;;
cuda/std/detail/libcxx/include/chrono:3121:107: error: expected ‘&gt;’ before ‘::’ token
cuda/std/detail/libcxx/include/chrono:3121:185: error: template argument 1 is invalid
     using precision = duration&lt;typename __CommonType::rep, ratio&lt;1, __pow10(fractional_width)&gt;&gt;;
cuda/std/detail/libcxx/include/chrono:3144:11: error: ‘precision’ does not name a type
     constexpr precision subseconds()    const noexcept { return __f; }
               ^~~~~~~~~
cuda/std/detail/libcxx/include/chrono:3147:11: error: ‘precision’ does not name a type
     constexpr precision to_duration() const noexcept
               ^~~~~~~~~
cuda/std/detail/libcxx/include/chrono:3154:29: error: expected type-specifier before ‘precision’
     constexpr explicit operator precision() const noexcept { return to_duration(); }
                                 ^~~~~~~~~
cuda/std/detail/libcxx/include/chrono:3161:1: error: ‘precision’ does not name a type
     precision       __f;
     ^   ~~~~~
cuda/std/detail/libcxx/include/chrono: In constructor ‘constexpr cuda::std::__3::chrono::hh_mm_ss&lt;_Duration&gt;::hh_mm_ss(_Duration)’:
cuda/std/detail/libcxx/include/chrono:3127:266: error: class ‘cuda::std::__3::chrono::hh_mm_ss&lt;_Duration&gt;’ does not have any field named ‘__f’
     constexpr explicit hh_mm_ss(_Duration __d) noexcept :
cuda/std/detail/libcxx/include/chrono:3127:285: error: ‘precision’ was not declared in this scope
     constexpr explicit hh_mm_ss(_Duration __d) noexcept :
</pre></details>