### PR TITLE
Skip libc++ tests for Clang 10 in DVS

### DIFF
--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_11/base.Dockerfile
@@ -68,6 +68,7 @@ RUN set -o pipefail; cd /sw/gpgpu/libcudacxx\
  LIBCUDACXX_SKIP_BASE_TESTS_BUILD=$LIBCUDACXX_SKIP_BASE_TESTS_BUILD\
  /sw/gpgpu/libcudacxx/utils/nvidia/linux/perform_tests.bash\
  --skip-tests-runs\
+ --skip-libcxx-tests\
  2>&1 | tee /sw/gpgpu/libcudacxx/build/build_lit_all.log
 
 # Build tests for sm6x if requested.

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_14/base.Dockerfile
@@ -68,6 +68,7 @@ RUN set -o pipefail; cd /sw/gpgpu/libcudacxx\
  LIBCUDACXX_SKIP_BASE_TESTS_BUILD=$LIBCUDACXX_SKIP_BASE_TESTS_BUILD\
  /sw/gpgpu/libcudacxx/utils/nvidia/linux/perform_tests.bash\
  --skip-tests-runs\
+ --skip-libcxx-tests\
  2>&1 | tee /sw/gpgpu/libcudacxx/build/build_lit_all.log
 
 # Build tests for sm6x if requested.

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_17/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_17/base.Dockerfile
@@ -68,6 +68,7 @@ RUN set -o pipefail; cd /sw/gpgpu/libcudacxx\
  LIBCUDACXX_SKIP_BASE_TESTS_BUILD=$LIBCUDACXX_SKIP_BASE_TESTS_BUILD\
  /sw/gpgpu/libcudacxx/utils/nvidia/linux/perform_tests.bash\
  --skip-tests-runs\
+ --skip-libcxx-tests\
  2>&1 | tee /sw/gpgpu/libcudacxx/build/build_lit_all.log
 
 # Build tests for sm6x if requested.


### PR DESCRIPTION
nv account: chengjiew@nvidia.com

Solving bug https://nvbugs/200644868 in this code submission.

Because this failure is caused by the libcxx test which should be neglected generally, I add the flag "skip-libcxx-test" for all clang10 build on Ubuntu18.04.

build can pass now: 
http://scdvs.nvidia.com/Query/User?which_user=component_history&build_component=cuda_dev+Release+Linux+AMD64+libcudacxx+Ubuntu-18.04+Clang-10+CXX-11
http://scdvs.nvidia.com/Query/User?which_user=component_history&build_component=cuda_dev+Release+Linux+AMD64+libcudacxx+Ubuntu-18.04+Clang-10+CXX-14
http://scdvs.nvidia.com/Query/User?which_user=component_history&build_component=cuda_dev+Release+Linux+AMD64+libcudacxx+Ubuntu-18.04+Clang-10+CXX-17