### PR TITLE
Rename the is_convertible fallback helper to avoid a clash with a keyword.

### DIFF
--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -1502,29 +1502,29 @@ struct __is_convertible_check<_Tp, 0>
 template <class _T1, class _T2,
     unsigned _T1_is_array_function_or_void = __is_convertible_imp::__is_array_function_or_void<_T1>::value,
     unsigned _T2_is_array_function_or_void = __is_convertible_imp::__is_array_function_or_void<_T2>::value>
-struct __is_convertible
+struct __is_convertible_fallback
     : public integral_constant<bool,
         __is_convertible_imp::__is_convertible_test<_T1, _T2>::value
     >
 {};
 
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 0, 1> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 1, 1> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 2, 1> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 3, 1> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 0, 1> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 1, 1> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 2, 1> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 3, 1> : public false_type {};
 
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 0, 2> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 1, 2> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 2, 2> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 3, 2> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 0, 2> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 1, 2> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 2, 2> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 3, 2> : public false_type {};
 
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 0, 3> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 1, 3> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 2, 3> : public false_type {};
-template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 3, 3> : public true_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 0, 3> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 1, 3> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 2, 3> : public false_type {};
+template <class _T1, class _T2> struct __is_convertible_fallback<_T1, _T2, 3, 3> : public true_type {};
 
 template <class _T1, class _T2> struct _LIBCUDACXX_TEMPLATE_VIS is_convertible
-    : public __is_convertible<_T1, _T2>
+    : public __is_convertible_fallback<_T1, _T2>
 {
     static const size_t __complete_check1 = __is_convertible_check<_T1>::__v;
     static const size_t __complete_check2 = __is_convertible_check<_T2>::__v;


### PR DESCRIPTION
NVCC has changed the behavior of Clang keywords like __is_convertible, so we
need to adjust.

Bug 3252533
Fixes #118

Running internal CI on CL 29638598.