### PR TITLE
Fixed Issue #126 (Compiler warnings when including "cuda/atomic" with CUDA 11.2)

### DIFF
--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -159,7 +159,11 @@ struct atomic<_Tp*, _Sco>
     _Tp* operator-=(ptrdiff_t __op) noexcept          {return fetch_sub(__op) - __op;}
 };
 
-inline __host__ __device__ void atomic_thread_fence(memory_order __m, thread_scope _Scope = thread_scope_system) {
+inline __host__ __device__ void atomic_thread_fence(memory_order __m, thread_scope
+#ifdef __CUDA_ARCH__
+_Scope
+#endif
+= thread_scope_system) {
 #ifdef __CUDA_ARCH__
     switch(_Scope) {
     case thread_scope_system:

--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -173,6 +173,7 @@ inline __host__ __device__ void atomic_thread_fence(memory_order __m, thread_sco
         break;
     }
 #else
+    (void) _Scope;
     ::std::atomic_thread_fence((::std::memory_order)__m);
 #endif
 }

--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -159,11 +159,7 @@ struct atomic<_Tp*, _Sco>
     _Tp* operator-=(ptrdiff_t __op) noexcept          {return fetch_sub(__op) - __op;}
 };
 
-inline __host__ __device__ void atomic_thread_fence(memory_order __m, thread_scope
-#ifdef __CUDA_ARCH__
-_Scope
-#endif
-= thread_scope_system) {
+inline __host__ __device__ void atomic_thread_fence(memory_order __m, thread_scope _Scope = thread_scope_system) {
 #ifdef __CUDA_ARCH__
     switch(_Scope) {
     case thread_scope_system:


### PR DESCRIPTION
Hello!

The pull request fixes #126 (Compiler warnings when including `cuda/atomic` with CUDA 11.2). I will be glad if it helps.

May I contribute to the project? And is it ok that I have taken already assigned issue? (noticed it too late) @wmaxey 