### PR TITLE
use python3 to avoid some syntax issue

### DIFF
--- a/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_7/cxx_11/base.Dockerfile
+++ b/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_7/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-7 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-7 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_7/cxx_14/base.Dockerfile
+++ b/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_7/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-7 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-7 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_8/cxx_11/base.Dockerfile
+++ b/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_8/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-8 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-8 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_8/cxx_14/base.Dockerfile
+++ b/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_8/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-8 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-8 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_8/cxx_17/base.Dockerfile
+++ b/docker/host_aarch64/ubuntu_18.04/target_aarch64/ubuntu_18.04/gcc_8/cxx_17/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-8 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-8 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/centos_7.6.1810/target_x86_64/centos_7.6.1810/gcc_4.8/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/centos_7.6.1810/target_x86_64/centos_7.6.1810/gcc_4.8/cxx_11/base.Dockerfile
@@ -14,8 +14,8 @@ SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN yum -y --enablerepo=extras install epel-release\
  && yum -y updateinfo\
- && yum -y install which make gcc-c++ libstdc++-static llvm-devel clang python python-pip\
- && pip install lit\
+ && yum -y install which make gcc-c++ libstdc++-static llvm-devel clang python3 python-pip\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/fedora_32/target_x86_64/fedora_32/gcc_10/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/fedora_32/target_x86_64/fedora_32/gcc_10/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN yum -y updateinfo\
- && yum -y install which findutils make gcc-c++ libstdc++-static llvm-devel clang python python-pip cmake\
- && pip install lit\
+ && yum -y install which findutils make gcc-c++ libstdc++-static llvm-devel clang python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/fedora_32/target_x86_64/fedora_32/gcc_10/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/fedora_32/target_x86_64/fedora_32/gcc_10/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN yum -y updateinfo\
- && yum -y install which findutils make gcc-c++ libstdc++-static llvm-devel clang python python-pip cmake\
- && pip install lit\
+ && yum -y install which findutils make gcc-c++ libstdc++-static llvm-devel clang python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/fedora_32/target_x86_64/fedora_32/gcc_10/cxx_17/base.Dockerfile
+++ b/docker/host_x86_64/fedora_32/target_x86_64/fedora_32/gcc_10/cxx_17/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN yum -y updateinfo\
- && yum -y install which findutils make gcc-c++ libstdc++-static llvm-devel clang python python-pip cmake\
- && pip install lit\
+ && yum -y install which findutils make gcc-c++ libstdc++-static llvm-devel clang python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_16.04/target_x86_64/ubuntu_16.04/gcc_5/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_16.04/target_x86_64/ubuntu_16.04/gcc_5/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-5 clang-5.0 python python-pip\
- && pip install lit\
+ && apt-get -y install g++-5 clang-5.0 python3 python-pip\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_16.04/target_x86_64/ubuntu_16.04/gcc_5/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_16.04/target_x86_64/ubuntu_16.04/gcc_5/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-5 clang-5.0 python python-pip\
- && pip install lit\
+ && apt-get -y install g++-5 clang-5.0 python3 python-pip\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-10 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-10 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-10 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-10 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_17/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_10/cxx_17/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-10 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-10 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_6/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_6/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_6/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_6/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_7/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_7/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-7 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-7 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_7/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_7/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-7 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-7 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_8/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_8/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-8 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-8 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_8/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_8/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-8 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-8 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_8/cxx_17/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_8/cxx_17/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-8 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-8 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_9/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_9/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-9 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-9 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_9/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_9/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-9 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-9 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_9/cxx_17/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/clang_9/cxx_17/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install clang-9 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install clang-9 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_6/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_6/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-6 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-6 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_6/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_6/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-6 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-6 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_7/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_7/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-7 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-7 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_7/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_7/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-7 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-7 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_8/cxx_11/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_8/cxx_11/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-8 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-8 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_8/cxx_14/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_8/cxx_14/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-8 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-8 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 

--- a/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_8/cxx_17/base.Dockerfile
+++ b/docker/host_x86_64/ubuntu_18.04/target_x86_64/ubuntu_18.04/gcc_8/cxx_17/base.Dockerfile
@@ -13,8 +13,8 @@ ARG LIBCUDACXX_COMPUTE_ARCHS
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 RUN apt-get -y update\
- && apt-get -y install g++-8 clang-6.0 python python-pip cmake\
- && pip install lit\
+ && apt-get -y install g++-8 clang-6.0 python3 python3-pip cmake\
+ && pip3 install lit\
  && mkdir -p /sw/gpgpu/libcudacxx/build\
  && mkdir -p /sw/gpgpu/libcudacxx/libcxx/build
 


### PR DESCRIPTION
new lit is released, but there is a syntax issue when we are using new lit tool

use Python3 can solve this issue:

http://scbuilds4u.nvidia.com/dvs/#/change/2995837939432407.1?showTab=DVS

the failures in this virtual is caused by NVCC compiler issue.