### PR TITLE
Make <nv/target> usable in C and C++98 compilations

### DIFF
--- a/include/nv/target
+++ b/include/nv/target
@@ -15,7 +15,7 @@
 
 #if defined(__NVCC__) || defined(__CUDACC_RTC__)
 #  define _NV_COMPILER_NVCC
-#elif defined(__NVCOMPILER)
+#elif defined(__NVCOMPILER) && __cplusplus >= 201103L
 #  define _NV_COMPILER_NVCXX
 #else
 #endif
@@ -25,6 +25,8 @@
 #else
 #  define _NV_BITSET_ATTRIBUTE
 #endif
+
+#if __cplusplus >= 201103L
 
 namespace nv {
   namespace target {
@@ -163,6 +165,8 @@ namespace nv {
     using detail::provides;
   }
 }
+
+#endif // C++11
 
 #include "detail/__target_macros"
 


### PR DESCRIPTION
The features of `<nv/target>` are only available in C++11 CUDA mode.  But some headers that use `<nv/target>` can be compiled, with limited functionality, as C or as C++98.  `<nv/target>` needs to do the same.

This change allows `<nv/target>` to be included successfully when compiling as C or as C++98.  In this situation, "`if target`" won't
work because the namespace `nv::target` won't exist, and the compatibility macros will assume host-only.