### PR TITLE
Remove XFAIL for CTAD tests on GCC-8/9 Clang-8 in <tuple> tests

### DIFF
--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -14,12 +14,12 @@
 // GCC's implementation of class template deduction is still immature and runs
 // into issues with libc++. However GCC accepts this code when compiling
 // against libstdc++.
-// XFAIL: gcc-5, gcc-6, gcc-7, gcc-8, gcc-9, gcc-10
+// XFAIL: gcc-5, gcc-6, gcc-7, gcc-10
 
 // UNSUPPORTED: nvrtc
 
 // Currently broken with Clang + NVCC.
-// XFAIL: clang
+// XFAIL: clang-6, clang-7, clang-9, clang-10
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -10,6 +10,7 @@
 // UNSUPPORTED: libcpp-no-deduction-guides
 // UNSUPPORTED: apple-clang-9
 // UNSUPPORTED: msvc
+// UNSUPPORTED: nvcc-10.3, nvcc-11.0, nvcc-11.1, nvcc-11.2, nvcc-11.3, nvcc-11.4
 
 // GCC's implementation of class template deduction is still immature and runs
 // into issues with libc++. However GCC accepts this code when compiling

--- a/.upstream-tests/test/std/utilities/utility/pairs/pairs.pair/implicit_deduction_guides.pass.cpp
+++ b/.upstream-tests/test/std/utilities/utility/pairs/pairs.pair/implicit_deduction_guides.pass.cpp
@@ -10,6 +10,7 @@
 // UNSUPPORTED: libcpp-no-deduction-guides
 // UNSUPPORTED: msvc
 // UNSUPPORTED: nvrtc
+// UNSUPPORTED: nvcc-10.3, nvcc-11.0, nvcc-11.1, nvcc-11.2, nvcc-11.3, nvcc-11.4
 
 // GCC's implementation of class template deduction is still immature and runs
 // into issues with libc++. However GCC accepts this code when compiling

--- a/.upstream-tests/test/std/utilities/utility/pairs/pairs.pair/implicit_deduction_guides.pass.cpp
+++ b/.upstream-tests/test/std/utilities/utility/pairs/pairs.pair/implicit_deduction_guides.pass.cpp
@@ -17,7 +17,7 @@
 // XFAIL: gcc
 
 // Currently broken with Clang + NVCC.
-// XFAIL: clang
+// XFAIL: clang-6, clang-7, clang-9, clang-10
 
 // <utility>
 


### PR DESCRIPTION
This fixes nvbug 200748254.

NVCC seems to have some proper CTAD support for these compilers and should now work as expected.