### PR TITLE
Fix upstream test warnings with /s/diag_suppress/nv_diag_suppress/

### DIFF
--- a/.upstream-tests/test/cuda/barrier_native_handle.pass.cpp
+++ b/.upstream-tests/test/cuda/barrier_native_handle.pass.cpp
@@ -9,8 +9,8 @@
 
 // UNSUPPORTED: pre-sm-70
 
-#pragma diag_suppress static_var_with_dynamic_init
-#pragma diag_suppress set_but_not_used
+#pragma nv_diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress set_but_not_used
 
 #include <cuda/barrier>
 

--- a/.upstream-tests/test/cuda/pipeline_arrive_on.pass.cpp
+++ b/.upstream-tests/test/cuda/pipeline_arrive_on.pass.cpp
@@ -9,8 +9,8 @@
 
 // UNSUPPORTED: pre-sm-70
 
-#pragma diag_suppress static_var_with_dynamic_init
-#pragma diag_suppress declared_but_not_referenced
+#pragma nv_diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress declared_but_not_referenced
 
 #include <cuda_pipeline.h>
 #include <cuda/barrier>

--- a/.upstream-tests/test/cuda/pipeline_arrive_on_abi_v2.pass.cpp
+++ b/.upstream-tests/test/cuda/pipeline_arrive_on_abi_v2.pass.cpp
@@ -11,8 +11,8 @@
 
 #define _LIBCUDACXX_CUDA_ABI_VERSION 2
 
-#pragma diag_suppress static_var_with_dynamic_init
-#pragma diag_suppress declared_but_not_referenced
+#pragma nv_diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress declared_but_not_referenced
 
 #include <cuda_pipeline.h>
 #include <cuda/barrier>

--- a/.upstream-tests/test/libcxx/libcpp_alignof.pass.cpp
+++ b/.upstream-tests/test/libcxx/libcpp_alignof.pass.cpp
@@ -16,7 +16,7 @@
 #include <cuda/std/type_traits>
 #include "test_macros.h"
 
-#pragma diag_suppress cuda_demote_unsupported_floating_point
+#pragma nv_diag_suppress cuda_demote_unsupported_floating_point
 
 template <class T>
 __host__ __device__

--- a/.upstream-tests/test/std/language.support/support.types/max_align_t.pass.cpp
+++ b/.upstream-tests/test/std/language.support/support.types/max_align_t.pass.cpp
@@ -17,7 +17,7 @@
 #endif // __CUDACC_RTC__
 #include "test_macros.h"
 
-#pragma diag_suppress cuda_demote_unsupported_floating_point
+#pragma nv_diag_suppress cuda_demote_unsupported_floating_point
 
 int main(int, char**)
 {

--- a/.upstream-tests/test/std/utilities/function.objects/func.invoke/invoke.pass.cpp
+++ b/.upstream-tests/test/std/utilities/function.objects/func.invoke/invoke.pass.cpp
@@ -42,7 +42,7 @@
 #include <cuda/std/utility> // for cuda::std::move
 #include <cuda/std/cassert>
 
-#pragma diag_suppress set_but_not_used
+#pragma nv_diag_suppress set_but_not_used
 
 struct NonCopyable {
     __host__ __device__

--- a/.upstream-tests/test/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
+++ b/.upstream-tests/test/std/utilities/function.objects/func.not_fn/not_fn.pass.cpp
@@ -23,7 +23,7 @@
 #include "test_macros.h"
 // #include "type_id.h"
 
-#pragma diag_suppress set_but_not_used
+#pragma nv_diag_suppress set_but_not_used
 
 ///////////////////////////////////////////////////////////////////////////////
 //                       CALLABLE TEST TYPES

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.cat/floating_point.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.cat/floating_point.pass.cpp
@@ -13,7 +13,7 @@
 #include <cuda/std/type_traits>
 #include "test_macros.h"
 
-#pragma diag_suppress cuda_demote_unsupported_floating_point
+#pragma nv_diag_suppress cuda_demote_unsupported_floating_point
 
 template <class T>
 __host__ __device__

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.cat/is_floating_point.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.cat/is_floating_point.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/cstddef>        // for cuda::std::nullptr_t
 #include "test_macros.h"
 
-#pragma diag_suppress cuda_demote_unsupported_floating_point
+#pragma nv_diag_suppress cuda_demote_unsupported_floating_point
 
 template <class T>
 __host__ __device__

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/floating_point.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/floating_point.pass.cpp
@@ -14,7 +14,7 @@
 
 #include "test_macros.h"
 
-#pragma diag_suppress cuda_demote_unsupported_floating_point
+#pragma nv_diag_suppress cuda_demote_unsupported_floating_point
 
 template <class T>
 __host__ __device__

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/is_fundamental.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/is_fundamental.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/cstddef>         // for cuda::std::nullptr_t
 #include "test_macros.h"
 
-#pragma diag_suppress cuda_demote_unsupported_floating_point
+#pragma nv_diag_suppress cuda_demote_unsupported_floating_point
 
 template <class T>
 __host__ __device__

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp
@@ -24,7 +24,7 @@
 #define LIBCPP11_STATIC_ASSERT(...) ((void)0)
 #endif
 
-#pragma diag_suppress declared_but_not_referenced
+#pragma nv_diag_suppress declared_but_not_referenced
 
 struct A
 {

--- a/.upstream-tests/test/std/utilities/time/date.time/ctime.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/date.time/ctime.pass.cpp
@@ -31,7 +31,7 @@
 #pragma GCC diagnostic ignored "-Wformat-zero-length"
 #endif
 
-#pragma diag_suppress set_but_not_used
+#pragma nv_diag_suppress set_but_not_used
 
 int main(int, char**)
 {

--- a/.upstream-tests/test/std/utilities/time/time.duration/time.duration.arithmetic/op_+.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.duration/time.duration.arithmetic/op_+.pass.cpp
@@ -17,7 +17,7 @@
 
 #include "test_macros.h"
 
-#pragma diag_suppress set_but_not_used
+#pragma nv_diag_suppress set_but_not_used
 
 int main(int, char**)
 {

--- a/.upstream-tests/test/std/utilities/time/time.duration/time.duration.arithmetic/op_-.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.duration/time.duration.arithmetic/op_-.pass.cpp
@@ -17,7 +17,7 @@
 
 #include "test_macros.h"
 
-#pragma diag_suppress set_but_not_used
+#pragma nv_diag_suppress set_but_not_used
 
 int main(int, char**)
 {


### PR DESCRIPTION
Internal compiler update removes compatibility with pragma_suppress flags. We need to remove these from the tests.

virtual: http://scdvs.nvidia.com/Build_Results?virtualId=1000073800&which_page=current_build
bug: https://nvbugs/200755268