### PR TITLE
Add `inline` and `constexpr` qualifiers to `__cxx_atomic_is_lock_free`

### DIFF
--- a/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcxx/include/support/atomic/atomic_cuda.h
@@ -106,6 +106,7 @@ namespace __host {
 #include "atomic_cuda_derived.h"
 
 _LIBCUDACXX_INLINE_VISIBILITY
+inline constexpr
  bool __cxx_atomic_is_lock_free(size_t __x) {
     return __x <= 8;
 }

--- a/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcxx/include/support/atomic/atomic_cuda.h
@@ -105,13 +105,13 @@ namespace __host {
 #include "atomic_cuda_generated.h"
 #include "atomic_cuda_derived.h"
 
-_LIBCUDACXX_INLINE_VISIBILITY
-inline constexpr
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
  bool __cxx_atomic_is_lock_free(size_t __x) {
     return __x <= 8;
 }
 
 _LIBCUDACXX_INLINE_VISIBILITY
+inline
  void __cxx_atomic_thread_fence(memory_order __order) {
     NV_DISPATCH_TARGET(
         NV_IS_DEVICE, (
@@ -124,6 +124,7 @@ _LIBCUDACXX_INLINE_VISIBILITY
 }
 
 _LIBCUDACXX_INLINE_VISIBILITY
+inline
  void __cxx_atomic_signal_fence(memory_order __order) {
     NV_DISPATCH_TARGET(
         NV_IS_DEVICE, (


### PR DESCRIPTION
This PR can either delete the function and use the `__host::` version, or override it and provide a definition more amenable for CUDA.

Either way they currently both do the same thing.