### PR TITLE
Fix `cuda::atomic<Integral>`'s `fetch_max/fetch_min` extension

### DIFF
--- a/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_fetch_max.pass.cpp
+++ b/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_fetch_max.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+#include <cuda/std/atomic>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "cuda_space_selector.h"
+
+template <class T, template<typename, typename> typename Selector, cuda::thread_scope>
+struct TestFn {
+  __host__ __device__
+  void operator()() const {
+    // Test greater
+    {
+        typedef cuda::atomic<T> A;
+        Selector<A, constructor_initializer> sel;
+        A & t = *sel.construct();
+        t = T(1);
+        assert(t.fetch_max(2) == T(1));
+        assert(t.load() == T(2));
+    }
+    {
+        typedef cuda::atomic<T> A;
+        Selector<volatile A, constructor_initializer> sel;
+        volatile A & t = *sel.construct();
+        t = T(1);
+        assert(t.fetch_max(2) == T(1));
+        assert(t.load() == T(2));
+    }
+    // Test not greater
+    {
+        typedef cuda::atomic<T> A;
+        Selector<A, constructor_initializer> sel;
+        A & t = *sel.construct();
+        t = T(3);
+        assert(t.fetch_max(2) == T(3));
+        assert(t.load() == T(3));
+    }
+    {
+        typedef cuda::atomic<T> A;
+        Selector<volatile A, constructor_initializer> sel;
+        volatile A & t = *sel.construct();
+        t = T(3);
+        assert(t.fetch_max(2) == T(3));
+        assert(t.load() == T(3));
+    }
+  }
+};
+
+int main(int, char**)
+{
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    TestEachIntegralType<TestFn, local_memory_selector>()();
+#endif
+#ifdef __CUDA_ARCH__
+    TestEachIntegralType<TestFn, shared_memory_selector>()();
+    TestEachIntegralType<TestFn, global_memory_selector>()();
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_fetch_min.pass.cpp
+++ b/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_fetch_min.pass.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+#include <cuda/std/atomic>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "cuda_space_selector.h"
+
+template <class T, template<typename, typename> typename Selector, cuda::thread_scope>
+struct TestFn {
+  __host__ __device__
+  void operator()() const {
+    // Test lesser
+    {
+        typedef cuda::atomic<T> A;
+        Selector<A, constructor_initializer> sel;
+        A & t = *sel.construct();
+        t = T(5);
+        assert(t.fetch_min(4) == T(5));
+        assert(t.load() == T(4));
+    }
+    {
+        typedef cuda::atomic<T> A;
+        Selector<volatile A, constructor_initializer> sel;
+        volatile A & t = *sel.construct();
+        t = T(5);
+        assert(t.fetch_min(4) == T(5));
+        assert(t.load() == T(4));
+    }
+    // Test not lesser
+    {
+        typedef cuda::atomic<T> A;
+        Selector<A, constructor_initializer> sel;
+        A & t = *sel.construct();
+        t = T(3);
+        assert(t.fetch_min(4) == T(3));
+        assert(t.load() == T(3));
+    }
+    {
+        typedef cuda::atomic<T> A;
+        Selector<volatile A, constructor_initializer> sel;
+        volatile A & t = *sel.construct();
+        t = T(3);
+        assert(t.fetch_min(4) == T(3));
+        assert(t.load() == T(3));
+    }
+  }
+};
+
+int main(int, char**)
+{
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    TestEachIntegralType<TestFn, local_memory_selector>()();
+#endif
+#ifdef __CUDA_ARCH__
+    TestEachIntegralType<TestFn, shared_memory_selector>()();
+    TestEachIntegralType<TestFn, global_memory_selector>()();
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_helpers.h
+++ b/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_helpers.h
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ATOMIC_HELPERS_H
+#define ATOMIC_HELPERS_H
+
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct UserAtomicType
+{
+    int i;
+
+    __host__ __device__
+    explicit UserAtomicType(int d = 0) TEST_NOEXCEPT : i(d) {}
+
+    __host__ __device__
+    friend bool operator==(const UserAtomicType& x, const UserAtomicType& y)
+    { return x.i == y.i; }
+};
+
+template < template <class, template<typename, typename> class, cuda::thread_scope> class TestFunctor,
+    template<typename, typename> class Selector, cuda::thread_scope Scope
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
+    = cuda::thread_scope_system
+#endif
+>
+struct TestEachIntegralType {
+    __host__ __device__
+    void operator()() const {
+        TestFunctor<char, Selector, Scope>()();
+        TestFunctor<signed char, Selector, Scope>()();
+        TestFunctor<unsigned char, Selector, Scope>()();
+        TestFunctor<short, Selector, Scope>()();
+        TestFunctor<unsigned short, Selector, Scope>()();
+        TestFunctor<int, Selector, Scope>()();
+        TestFunctor<unsigned int, Selector, Scope>()();
+        TestFunctor<long, Selector, Scope>()();
+        TestFunctor<unsigned long, Selector, Scope>()();
+        TestFunctor<long long, Selector, Scope>()();
+        TestFunctor<unsigned long long, Selector, Scope>()();
+        TestFunctor<wchar_t, Selector, Scope>();
+#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+        TestFunctor<char16_t, Selector, Scope>()();
+        TestFunctor<char32_t, Selector, Scope>()();
+#endif
+        TestFunctor<  int8_t, Selector, Scope>()();
+        TestFunctor< uint8_t, Selector, Scope>()();
+        TestFunctor< int16_t, Selector, Scope>()();
+        TestFunctor<uint16_t, Selector, Scope>()();
+        TestFunctor< int32_t, Selector, Scope>()();
+        TestFunctor<uint32_t, Selector, Scope>()();
+        TestFunctor< int64_t, Selector, Scope>()();
+        TestFunctor<uint64_t, Selector, Scope>()();
+    }
+};
+
+template < template <class, template<typename, typename> class, cuda::thread_scope> class TestFunctor,
+    template<typename, typename> class Selector, cuda::thread_scope Scope
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
+    = cuda::thread_scope_system
+#endif
+>
+struct TestEachAtomicType {
+    __host__ __device__
+    void operator()() const {
+        TestEachIntegralType<TestFunctor, Selector, Scope>()();
+        TestFunctor<UserAtomicType, Selector, Scope>()();
+        TestFunctor<int*, Selector, Scope>()();
+        TestFunctor<const int*, Selector, Scope>()();
+    }
+};
+
+
+#endif // ATOMIC_HELPER_H

--- a/.upstream-tests/test/cuda/atomics/atomic.ext/nothing_to_do.pass.cpp
+++ b/.upstream-tests/test/cuda/atomics/atomic.ext/nothing_to_do.pass.cpp
@@ -1,0 +1,14 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+int main(int, char**)
+{
+
+  return 0;
+}

--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -98,15 +98,13 @@ struct atomic
     __host__ __device__
     _Tp fetch_max(const _Tp & __op, memory_order __m = memory_order_seq_cst) volatile noexcept
     {
-        return std::__detail::__atomic_fetch_max_cuda(&this->__a_.__a_value, __op,
-                                              __m, std::__detail::__scope_tag<_Sco>());
+        return std::__detail::__cxx_atomic_fetch_max(&this->__a_, __op, __m);
     }
 
     __host__ __device__
     _Tp fetch_min(const _Tp & __op, memory_order __m = memory_order_seq_cst) volatile noexcept
     {
-        return std::__detail::__atomic_fetch_min_cuda(&this->__a_.__a_value, __op,
-                                              __m, std::__detail::__scope_tag<_Sco>());
+        return std::__detail::__cxx_atomic_fetch_min(&this->__a_, __op, __m);
     }
 };
 

--- a/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcxx/include/support/atomic/atomic_cuda.h
@@ -396,7 +396,7 @@ __host__ __device__
     _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
     _Tp __desired = __expected < __val ? __expected : __val;
 
-    while(__desired != __val &&
+    while(__desired == __val &&
             !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
         __desired = __expected < __val ? __expected : __val;
     }

--- a/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcxx/include/support/atomic/atomic_cuda.h
@@ -379,29 +379,43 @@ __host__ __device__
 template <typename _Tp, typename _Delta, int _Sco, bool _Ref>
 __host__ __device__
  _Tp __cxx_atomic_fetch_max(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a, _Delta __val, memory_order __order) {
-    _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
-    _Tp __desired = __expected > __val ? __expected : __val;
+    NV_IF_TARGET(
+        NV_IS_DEVICE, (
+            return __atomic_fetch_max_cuda(__cxx_get_underlying_device_atomic(__a), __val, __order, __scope_tag<_Sco>());
+        ), (
+            // IS_HOST
+            _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
+            _Tp __desired = __expected > __val ? __expected : __val;
 
-    while(__desired == __val &&
-            !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
-        __desired = __expected > __val ? __expected : __val;
-    }
+            while(__desired == __val &&
+                    !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
+                __desired = __expected > __val ? __expected : __val;
+            }
 
-    return __expected;
+            return __expected;
+        )
+    )
 }
 
 template <typename _Tp, typename _Delta, int _Sco, bool _Ref>
 __host__ __device__
  _Tp __cxx_atomic_fetch_min(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a, _Delta __val, memory_order __order) {
-    _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
-    _Tp __desired = __expected < __val ? __expected : __val;
+    NV_IF_TARGET(
+        NV_IS_DEVICE, (
+            return __atomic_fetch_min_cuda(__cxx_get_underlying_device_atomic(__a), __val, __order, __scope_tag<_Sco>());
+        ), (
+            // IS_HOST
+            _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
+            _Tp __desired = __expected < __val ? __expected : __val;
 
-    while(__desired == __val &&
-            !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
-        __desired = __expected < __val ? __expected : __val;
-    }
+            while(__desired == __val &&
+                    !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
+                __desired = __expected < __val ? __expected : __val;
+            }
 
-    return __expected;
+            return __expected;
+        )
+    )
 }
 
 template<class _Tp>

--- a/libcxx/include/support/atomic/atomic_cuda.h
+++ b/libcxx/include/support/atomic/atomic_cuda.h
@@ -376,6 +376,34 @@ __host__ __device__
     )
 }
 
+template <typename _Tp, typename _Delta, int _Sco, bool _Ref>
+__host__ __device__
+ _Tp __cxx_atomic_fetch_max(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a, _Delta __val, memory_order __order) {
+    _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
+    _Tp __desired = __expected > __val ? __expected : __val;
+
+    while(__desired == __val &&
+            !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
+        __desired = __expected > __val ? __expected : __val;
+    }
+
+    return __expected;
+}
+
+template <typename _Tp, typename _Delta, int _Sco, bool _Ref>
+__host__ __device__
+ _Tp __cxx_atomic_fetch_min(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a, _Delta __val, memory_order __order) {
+    _Tp __expected = __cxx_atomic_load(__a, memory_order_relaxed);
+    _Tp __desired = __expected < __val ? __expected : __val;
+
+    while(__desired != __val &&
+            !__cxx_atomic_compare_exchange_strong(__a, &__expected, __desired, __order, __order)) {
+        __desired = __expected < __val ? __expected : __val;
+    }
+
+    return __expected;
+}
+
 template<class _Tp>
 __host__ __device__ inline uint32_t __cxx_small_to_32(_Tp __val) {
     __cxx_small_proxy<_Tp> __temp = 0;
@@ -478,4 +506,14 @@ __host__ __device__ inline _Tp __cxx_atomic_fetch_or(__cxx_atomic_base_small_imp
 template <typename _Tp, int _Sco>
 __host__ __device__ inline _Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_small_impl<_Tp, _Sco> volatile* __a, _Tp __pattern, memory_order __order) {
     return __cxx_small_from_32<_Tp>(__cxx_atomic_fetch_xor(&__a->__a_value, __cxx_small_to_32(__pattern), __order));
+}
+
+template <typename _Tp, typename _Delta, int _Sco>
+__host__ __device__ inline _Tp __cxx_atomic_fetch_max(__cxx_atomic_base_small_impl<_Tp, _Sco> volatile* __a, _Delta __val, memory_order __order) {
+    return __cxx_small_from_32<_Tp>(__cxx_atomic_fetch_max(&__a->__a_value, __cxx_small_to_32(__val), __order));
+}
+
+template <typename _Tp, typename _Delta, int _Sco>
+__host__ __device__ inline _Tp __cxx_atomic_fetch_min(__cxx_atomic_base_small_impl<_Tp, _Sco> volatile* __a, _Delta __val, memory_order __order) {
+    return __cxx_small_from_32<_Tp>(__cxx_atomic_fetch_min(&__a->__a_value, __cxx_small_to_32(__val), __order));
 }

--- a/libcxx/include/support/atomic/atomic_cuda_derived.h
+++ b/libcxx/include/support/atomic/atomic_cuda_derived.h
@@ -48,52 +48,6 @@ _Type __device__ __atomic_fetch_add_cuda(_Type volatile *__ptr, _Delta __val, in
 }
 
 template<class _Type, class _Delta, class _Scope, typename _CUDA_VSTD::enable_if<sizeof(_Type)<=2, int>::type = 0>
-_Type __host__ __device__ __atomic_fetch_max_cuda(_Type volatile *__ptr, _Delta __val, int __memorder, _Scope __s) {
-
-    _Type __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, __s);
-    _Type __desired = __expected > __val ? __expected : __val;
-    NV_DISPATCH_TARGET(
-        NV_IS_DEVICE, (
-            while(__desired == __val &&
-                  !__atomic_compare_exchange_cuda(__ptr, &__expected, &__desired, true, __memorder, __memorder, __s)) {
-               __desired = __expected > __val ? __expected : __val;
-            }
-            return __expected;
-        ),
-        NV_IS_HOST, (
-            while(__desired == __val &&
-                  !__atomic_compare_exchange(__ptr, &__expected, &__desired, true, __memorder, __memorder)) {
-                __desired = __expected > __val ? __expected : __val;
-            }
-            return __expected;
-        )
-    )
-}
-
-template<class _Type, class _Delta, class _Scope, typename _CUDA_VSTD::enable_if<sizeof(_Type)<=2, int>::type = 0>
-_Type __host__ __device__ __atomic_fetch_min_cuda(_Type volatile *__ptr, _Delta __val, int __memorder, _Scope __s) {
-
-    _Type __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, __s);
-    _Type __desired = __expected < __val ? __expected : __val;
-    NV_DISPATCH_TARGET(
-        NV_IS_DEVICE, (
-            while(__desired != __val &&
-                  !__atomic_compare_exchange_cuda(__ptr, &__expected, &__desired, true, __memorder, __memorder, __s)) {
-                __desired = __expected < __val ? __expected : __val;
-            }
-            return __expected;
-        ),
-        NV_IS_HOST, (
-            while(__desired != __val &&
-                  !__atomic_compare_exchange(__ptr, &__expected, &__desired, true, __memorder, __memorder)) {
-                __desired = __expected < __val ? __expected : __val;
-            }
-            return __expected;
-        )
-    )
-}
-
-template<class _Type, class _Delta, class _Scope, typename _CUDA_VSTD::enable_if<sizeof(_Type)<=2, int>::type = 0>
 _Type __device__ __atomic_fetch_sub_cuda(_Type volatile *__ptr, _Delta __val, int __memorder, _Scope __s) {
 
     _Type __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, __s);

--- a/libcxx/include/support/atomic/atomic_cuda_derived.h
+++ b/libcxx/include/support/atomic/atomic_cuda_derived.h
@@ -48,6 +48,32 @@ _Type __device__ __atomic_fetch_add_cuda(_Type volatile *__ptr, _Delta __val, in
 }
 
 template<class _Type, class _Delta, class _Scope, typename _CUDA_VSTD::enable_if<sizeof(_Type)<=2, int>::type = 0>
+_Type __host__ __device__ __atomic_fetch_max_cuda(_Type volatile *__ptr, _Delta __val, int __memorder, _Scope __s) {
+    _Type __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, __s);
+    _Type __desired = __expected > __val ? __expected : __val;
+
+    while(__desired == __val &&
+            !__atomic_compare_exchange_cuda(__ptr, &__expected, &__desired, true, __memorder, __memorder, __s)) {
+        __desired = __expected > __val ? __expected : __val;
+    }
+
+    return __expected;
+}
+
+template<class _Type, class _Delta, class _Scope, typename _CUDA_VSTD::enable_if<sizeof(_Type)<=2, int>::type = 0>
+_Type __host__ __device__ __atomic_fetch_min_cuda(_Type volatile *__ptr, _Delta __val, int __memorder, _Scope __s) {
+    _Type __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, __s);
+    _Type __desired = __expected < __val ? __expected : __val;
+
+    while(__desired != __val &&
+            !__atomic_compare_exchange_cuda(__ptr, &__expected, &__desired, true, __memorder, __memorder, __s)) {
+        __desired = __expected < __val ? __expected : __val;
+    }
+
+    return __expected;
+}
+
+template<class _Type, class _Delta, class _Scope, typename _CUDA_VSTD::enable_if<sizeof(_Type)<=2, int>::type = 0>
 _Type __device__ __atomic_fetch_sub_cuda(_Type volatile *__ptr, _Delta __val, int __memorder, _Scope __s) {
 
     _Type __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, __s);


### PR DESCRIPTION
There was previously no testing, and this has been broken since 1.3.0. I am unable to test back further.