### PR TITLE
WIP: Implement `atomic_ref`

### DIFF
--- a/.upstream-tests/test/cuda/bad_atomic_alignment.pass.cpp
+++ b/.upstream-tests/test/cuda/bad_atomic_alignment.pass.cpp
@@ -31,7 +31,7 @@ int main(int argc, char ** argv)
       int32_t b;
     };
     static_assert(alignof(key) == 4, "");
-    cuda::atomic<key> k;
+    cuda::atomic<key> k(key{});
     auto r = k.load();
     k.store(r);
     (void)k.exchange(r);
@@ -44,7 +44,7 @@ int main(int argc, char ** argv)
       int32_t b;
     };
     static_assert(alignof(key) == 8, "");
-    cuda::atomic<key> k;
+    cuda::atomic<key> k(key{});
     auto r = k.load();
     k.store(r);
     (void)k.exchange(r);

--- a/.upstream-tests/test/heterogeneous/atomic_ref.pass.cpp
+++ b/.upstream-tests/test/heterogeneous/atomic_ref.pass.cpp
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+#include "helpers.h"
+
+#include <cuda/std/atomic>
+
+template<int Operand>
+struct store_tester
+{
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        a.store(static_cast<T>(Operand));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Operand));
+    }
+};
+
+template<int PreviousValue, int Operand>
+struct exchange_tester
+{
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        assert(a.exchange(static_cast<T>(Operand)) == static_cast<T>(PreviousValue));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Operand));
+    }
+};
+
+template<int PreviousValue, int Expected, int Desired, int Result>
+struct strong_cas_tester
+{
+    enum { ShouldSucceed = (Expected == PreviousValue) };
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        T expected = static_cast<T>(Expected);
+        assert(a.compare_exchange_strong(expected, static_cast<T>(Desired)) == ShouldSucceed);
+        assert(expected == static_cast<T>(PreviousValue));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Result));
+    }
+};
+
+template<int PreviousValue, int Expected, int Desired, int Result>
+struct weak_cas_tester
+{
+    enum { ShouldSucceed = (Expected == PreviousValue) };
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        T expected = static_cast<T>(Expected);
+        if (!ShouldSucceed)
+        {
+            assert(a.compare_exchange_weak(expected, static_cast<T>(Desired)) == false);
+        }
+        else
+        {
+            while (a.compare_exchange_weak(expected, static_cast<T>(Desired)) != ShouldSucceed) ;
+        }
+        assert(expected == static_cast<T>(PreviousValue));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::std::atomic_ref<A> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Result));
+    }
+};
+
+#define ATOMIC_TESTER(operation) \
+    template<int PreviousValue, int Operand, int ExpectedValue> \
+    struct operation ## _tester \
+    { \
+        template<typename A> \
+        __host__ __device__ \
+        static void initialize(A & v) \
+        { \
+            cuda::std::atomic_ref<A> a(v); \
+            using T = decltype(a.load()); \
+            assert(a.operation(Operand) == static_cast<T>(PreviousValue)); \
+        } \
+        \
+        template<typename A> \
+        __host__ __device__ \
+        static void validate(A & v) \
+        { \
+            cuda::std::atomic_ref<A> a(v); \
+            using T = decltype(a.load()); \
+            assert(a.load() == static_cast<T>(ExpectedValue)); \
+        } \
+    };
+
+ATOMIC_TESTER(fetch_add);
+ATOMIC_TESTER(fetch_sub);
+
+ATOMIC_TESTER(fetch_and);
+ATOMIC_TESTER(fetch_or);
+ATOMIC_TESTER(fetch_xor);
+
+using basic_testers = tester_list<
+    store_tester<0>,
+    store_tester<-1>,
+    store_tester<17>,
+    exchange_tester<17, 31>,
+    /* *_cas_tester<PreviousValue, Expected, Desired, Result> */
+    weak_cas_tester<31, 12, 13, 31>,
+    weak_cas_tester<31, 31, -6, -6>,
+    strong_cas_tester<-6, -6, -12, -12>,
+    strong_cas_tester<-12, 31, 17, -12>,
+    exchange_tester<-12, 17>
+>;
+
+using arithmetic_atomic_testers = extend_tester_list<
+    basic_testers,
+    fetch_add_tester<17, 13, 30>,
+    fetch_sub_tester<30, 21, 9>,
+    fetch_sub_tester<9, 17, -8>
+>;
+
+using bitwise_atomic_testers = extend_tester_list<
+    arithmetic_atomic_testers,
+    fetch_add_tester<-8, 10, 2>,
+    fetch_or_tester<2, 13, 15>,
+    fetch_and_tester<15, 8, 8>,
+    fetch_and_tester<8, 13, 8>,
+    fetch_xor_tester<8, 12, 4>
+>;
+
+void kernel_invoker()
+{
+  // todo
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<signed char, arithmetic_atomic_testers>();
+    validate_not_movable<signed short, arithmetic_atomic_testers>();
+  #endif
+    validate_not_movable<signed int, arithmetic_atomic_testers>();
+    validate_not_movable<signed long, arithmetic_atomic_testers>();
+    validate_not_movable<signed long long, arithmetic_atomic_testers>();
+
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<unsigned char, bitwise_atomic_testers>();
+    validate_not_movable<unsigned short, bitwise_atomic_testers>();
+  #endif
+    validate_not_movable<unsigned int, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long long, bitwise_atomic_testers>();
+
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<signed char, arithmetic_atomic_testers>();
+    validate_not_movable<signed short, arithmetic_atomic_testers>();
+  #endif
+    validate_not_movable<signed int, arithmetic_atomic_testers>();
+    validate_not_movable<signed long, arithmetic_atomic_testers>();
+    validate_not_movable<signed long long, arithmetic_atomic_testers>();
+
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<unsigned char, bitwise_atomic_testers>();
+    validate_not_movable<unsigned short, bitwise_atomic_testers>();
+  #endif
+    validate_not_movable<unsigned int, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long long, bitwise_atomic_testers>();
+}
+
+int main(int arg, char ** argv)
+{
+#ifndef __CUDA_ARCH__
+    kernel_invoker();
+#endif
+
+    return 0;
+}

--- a/.upstream-tests/test/heterogeneous/cuda_atomic_ref.pass.cpp
+++ b/.upstream-tests/test/heterogeneous/cuda_atomic_ref.pass.cpp
@@ -1,0 +1,224 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+#include "helpers.h"
+
+#include <cuda/atomic>
+
+template<int Operand>
+struct store_tester
+{
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        a.store(static_cast<T>(Operand));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Operand));
+    }
+};
+
+template<int PreviousValue, int Operand>
+struct exchange_tester
+{
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        assert(a.exchange(static_cast<T>(Operand)) == static_cast<T>(PreviousValue));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Operand));
+    }
+};
+
+template<int PreviousValue, int Expected, int Desired, int Result>
+struct strong_cas_tester
+{
+    enum { ShouldSucceed = (Expected == PreviousValue) };
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        T expected = static_cast<T>(Expected);
+        assert(a.compare_exchange_strong(expected, static_cast<T>(Desired)) == ShouldSucceed);
+        assert(expected == static_cast<T>(PreviousValue));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Result));
+    }
+};
+
+template<int PreviousValue, int Expected, int Desired, int Result>
+struct weak_cas_tester
+{
+    enum { ShouldSucceed = (Expected == PreviousValue) };
+    template<typename A>
+    __host__ __device__
+    static void initialize(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        T expected = static_cast<T>(Expected);
+        if (!ShouldSucceed)
+        {
+            assert(a.compare_exchange_weak(expected, static_cast<T>(Desired)) == false);
+        }
+        else
+        {
+            while (a.compare_exchange_weak(expected, static_cast<T>(Desired)) != ShouldSucceed) ;
+        }
+        assert(expected == static_cast<T>(PreviousValue));
+    }
+
+    template<typename A>
+    __host__ __device__
+    static void validate(A & v)
+    {
+        cuda::atomic_ref<A, cuda::thread_scope_system> a(v);
+        using T = decltype(a.load());
+        assert(a.load() == static_cast<T>(Result));
+    }
+};
+
+#define ATOMIC_TESTER(operation) \
+    template<int PreviousValue, int Operand, int ExpectedValue> \
+    struct operation ## _tester \
+    { \
+        template<typename A> \
+        __host__ __device__ \
+        static void initialize(A & v) \
+        { \
+            cuda::atomic_ref<A, cuda::thread_scope_system> a(v); \
+            using T = decltype(a.load()); \
+            assert(a.operation(Operand) == static_cast<T>(PreviousValue)); \
+        } \
+        \
+        template<typename A> \
+        __host__ __device__ \
+        static void validate(A & v) \
+        { \
+            cuda::atomic_ref<A, cuda::thread_scope_system> a(v); \
+            using T = decltype(a.load()); \
+            assert(a.load() == static_cast<T>(ExpectedValue)); \
+        } \
+    };
+
+ATOMIC_TESTER(fetch_add);
+ATOMIC_TESTER(fetch_sub);
+
+ATOMIC_TESTER(fetch_and);
+ATOMIC_TESTER(fetch_or);
+ATOMIC_TESTER(fetch_xor);
+
+ATOMIC_TESTER(fetch_min);
+ATOMIC_TESTER(fetch_max);
+
+using basic_testers = tester_list<
+    store_tester<0>,
+    store_tester<-1>,
+    store_tester<17>,
+    exchange_tester<17, 31>,
+    /* *_cas_tester<PreviousValue, Expected, Desired, Result> */
+    weak_cas_tester<31, 12, 13, 31>,
+    weak_cas_tester<31, 31, -6, -6>,
+    strong_cas_tester<-6, -6, -12, -12>,
+    strong_cas_tester<-12, 31, 17, -12>,
+    exchange_tester<-12, 17>
+>;
+
+using arithmetic_atomic_testers = extend_tester_list<
+    basic_testers,
+    fetch_add_tester<17, 13, 30>,
+    fetch_sub_tester<30, 21, 9>,
+    fetch_min_tester<9, 5, 5>,
+    fetch_max_tester<5, 9, 9>,
+    fetch_sub_tester<9, 17, -8>,
+>;
+
+using bitwise_atomic_testers = extend_tester_list<
+    arithmetic_atomic_testers,
+    fetch_add_tester<-8, 10, 2>,
+    fetch_or_tester<2, 13, 15>,
+    fetch_and_tester<15, 8, 8>,
+    fetch_and_tester<8, 13, 8>,
+    fetch_xor_tester<8, 12, 4>
+>;
+
+void kernel_invoker()
+{
+  // todo
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<signed char, arithmetic_atomic_testers>();
+    validate_not_movable<signed short, arithmetic_atomic_testers>();
+  #endif
+    validate_not_movable<signed int, arithmetic_atomic_testers>();
+    validate_not_movable<signed long, arithmetic_atomic_testers>();
+    validate_not_movable<signed long long, arithmetic_atomic_testers>();
+
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<unsigned char, bitwise_atomic_testers>();
+    validate_not_movable<unsigned short, bitwise_atomic_testers>();
+  #endif
+    validate_not_movable<unsigned int, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long long, bitwise_atomic_testers>();
+
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<signed char, arithmetic_atomic_testers>();
+    validate_not_movable<signed short, arithmetic_atomic_testers>();
+  #endif
+    validate_not_movable<signed int, arithmetic_atomic_testers>();
+    validate_not_movable<signed long, arithmetic_atomic_testers>();
+    validate_not_movable<signed long long, arithmetic_atomic_testers>();
+
+  #ifdef _LIBCUDACXX_ATOMIC_REF_SUPPORTS_SMALL_INTEGRAL
+    validate_not_movable<unsigned char, bitwise_atomic_testers>();
+    validate_not_movable<unsigned short, bitwise_atomic_testers>();
+  #endif
+    validate_not_movable<unsigned int, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long, bitwise_atomic_testers>();
+    validate_not_movable<unsigned long long, bitwise_atomic_testers>();
+}
+
+int main(int arg, char ** argv)
+{
+#ifndef __CUDA_ARCH__
+    kernel_invoker();
+#endif
+
+    return 0;
+}

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/address_ref.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/address_ref.pass.cpp
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+//  ... test case crashes clang.
+
+// <cuda/std/atomic>
+
+// template <class T>
+// struct atomic<T*>
+// {
+//     bool is_lock_free() const volatile;
+//     bool is_lock_free() const;
+//     void store(T* desr, memory_order m = memory_order_seq_cst) volatile;
+//     void store(T* desr, memory_order m = memory_order_seq_cst);
+//     T* load(memory_order m = memory_order_seq_cst) const volatile;
+//     T* load(memory_order m = memory_order_seq_cst) const;
+//     operator T*() const volatile;
+//     operator T*() const;
+//     T* exchange(T* desr, memory_order m = memory_order_seq_cst) volatile;
+//     T* exchange(T* desr, memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order s, memory_order f) volatile;
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order s, memory_order f);
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order s, memory_order f) volatile;
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order s, memory_order f);
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                 memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order m = memory_order_seq_cst);
+//     T* fetch_add(ptrdiff_t op, memory_order m = memory_order_seq_cst) volatile;
+//     T* fetch_add(ptrdiff_t op, memory_order m = memory_order_seq_cst);
+//     T* fetch_sub(ptrdiff_t op, memory_order m = memory_order_seq_cst) volatile;
+//     T* fetch_sub(ptrdiff_t op, memory_order m = memory_order_seq_cst);
+//
+//     atomic() = default;
+//     constexpr atomic(T* desr);
+//     atomic(const atomic&) = delete;
+//     atomic& operator=(const atomic&) = delete;
+//     atomic& operator=(const atomic&) volatile = delete;
+//
+//     T* operator=(T*) volatile;
+//     T* operator=(T*);
+//     T* operator++(int) volatile;
+//     T* operator++(int);
+//     T* operator--(int) volatile;
+//     T* operator--(int);
+//     T* operator++() volatile;
+//     T* operator++();
+//     T* operator--() volatile;
+//     T* operator--();
+//     T* operator+=(ptrdiff_t op) volatile;
+//     T* operator+=(ptrdiff_t op);
+//     T* operator-=(ptrdiff_t op) volatile;
+//     T* operator-=(ptrdiff_t op);
+// };
+
+#include <cuda/std/atomic>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include <cmpxchg_loop.h>
+
+#include "test_macros.h"
+#if !defined(TEST_COMPILER_C1XX)
+  #include "placement_new.h"
+#endif
+#include "cuda_space_selector.h"
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__
+void
+do_test()
+{
+    typedef typename cuda::std::remove_pointer<T>::type X;
+    Selector<T, constructor_initializer> sel;
+    T & val = *sel.construct(T(0));
+    A obj(val);
+    bool b0 = obj.is_lock_free();
+    ((void)b0); // mark as unused
+    assert(obj == T(0));
+    obj.store(T(0));
+    assert(obj == T(0));
+    obj.store(T(1), cuda::std::memory_order_release);
+    assert(obj == T(1));
+    assert(obj.load() == T(1));
+    assert(obj.load(cuda::std::memory_order_acquire) == T(1));
+    assert(obj.exchange(T(2)) == T(1));
+    assert(obj == T(2));
+    assert(obj.exchange(T(3), cuda::std::memory_order_relaxed) == T(2));
+    assert(obj == T(3));
+    T x = obj;
+    assert(cmpxchg_weak_loop(obj, x, T(2)) == true);
+    assert(obj == T(2));
+    assert(x == T(3));
+    assert(obj.compare_exchange_weak(x, T(1)) == false);
+    assert(obj == T(2));
+    assert(x == T(2));
+    x = T(2);
+    assert(obj.compare_exchange_strong(x, T(1)) == true);
+    assert(obj == T(1));
+    assert(x == T(2));
+    assert(obj.compare_exchange_strong(x, T(0)) == false);
+    assert(obj == T(1));
+    assert(x == T(1));
+    assert((obj = T(0)) == T(0));
+    assert(obj == T(0));
+    obj = T(2*sizeof(X));
+    assert((obj += cuda::std::ptrdiff_t(3)) == T(5*sizeof(X)));
+    assert(obj == T(5*sizeof(X)));
+    assert((obj -= cuda::std::ptrdiff_t(3)) == T(2*sizeof(X)));
+    assert(obj == T(2*sizeof(X)));
+}
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__
+void test()
+{
+    do_test<A, T, Selector>();
+    do_test<volatile A, T, Selector>();
+}
+
+int main(int, char**)
+{
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    test<cuda::std::atomic_ref<int*>, int*, local_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_system>, int*, local_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_device>, int*, local_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_block>, int*, local_memory_selector>();
+#endif
+#ifdef __CUDA_ARCH__
+    test<cuda::std::atomic_ref<int*>, int*, shared_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_system>, int*, shared_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_device>, int*, shared_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_block>, int*, shared_memory_selector>();
+
+    test<cuda::std::atomic_ref<int*>, int*, global_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_system>, int*, global_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_device>, int*, global_memory_selector>();
+    test<cuda::atomic_ref<int*, cuda::thread_scope_block>, int*, global_memory_selector>();
+#endif
+  return 0;
+}

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/address_ref.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/address_ref.pass.cpp
@@ -13,7 +13,7 @@
 // <cuda/std/atomic>
 
 // template <class T>
-// struct atomic<T*>
+// struct atomic_ref<T*>
 // {
 //     bool is_lock_free() const volatile;
 //     bool is_lock_free() const;

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/address_ref_constness.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/address_ref_constness.pass.cpp
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+//  ... test case crashes clang.
+
+// <cuda/std/atomic>
+
+// template <class T>
+// struct atomic<T*>
+// {
+//     bool is_lock_free() const volatile;
+//     bool is_lock_free() const;
+//     void store(T* desr, memory_order m = memory_order_seq_cst) volatile;
+//     void store(T* desr, memory_order m = memory_order_seq_cst);
+//     T* load(memory_order m = memory_order_seq_cst) const volatile;
+//     T* load(memory_order m = memory_order_seq_cst) const;
+//     operator T*() const volatile;
+//     operator T*() const;
+//     T* exchange(T* desr, memory_order m = memory_order_seq_cst) volatile;
+//     T* exchange(T* desr, memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order s, memory_order f) volatile;
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order s, memory_order f);
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order s, memory_order f) volatile;
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order s, memory_order f);
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                 memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order m = memory_order_seq_cst);
+//     T* fetch_add(ptrdiff_t op, memory_order m = memory_order_seq_cst) volatile;
+//     T* fetch_add(ptrdiff_t op, memory_order m = memory_order_seq_cst);
+//     T* fetch_sub(ptrdiff_t op, memory_order m = memory_order_seq_cst) volatile;
+//     T* fetch_sub(ptrdiff_t op, memory_order m = memory_order_seq_cst);
+//
+//     atomic() = default;
+//     constexpr atomic(T* desr);
+//     atomic(const atomic&) = delete;
+//     atomic& operator=(const atomic&) = delete;
+//     atomic& operator=(const atomic&) volatile = delete;
+//
+//     T* operator=(T*) volatile;
+//     T* operator=(T*);
+//     T* operator++(int) volatile;
+//     T* operator++(int);
+//     T* operator--(int) volatile;
+//     T* operator--(int);
+//     T* operator++() volatile;
+//     T* operator++();
+//     T* operator--() volatile;
+//     T* operator--();
+//     T* operator+=(ptrdiff_t op) volatile;
+//     T* operator+=(ptrdiff_t op);
+//     T* operator-=(ptrdiff_t op) volatile;
+//     T* operator-=(ptrdiff_t op);
+// };
+
+#include <cuda/std/atomic>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include <cmpxchg_loop.h>
+
+#include "test_macros.h"
+#if !defined(TEST_COMPILER_C1XX)
+  #include "placement_new.h"
+#endif
+#include "cuda_space_selector.h"
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__
+void
+do_test()
+{
+    typedef typename cuda::std::remove_pointer<T>::type X;
+    Selector<T, constructor_initializer> sel;
+    T & val = *sel.construct(T(0));
+    A obj(val);
+    bool b0 = obj.is_lock_free();
+    ((void)b0); // mark as unused
+    assert(obj == T(0));
+    obj.store(T(0));
+    assert(obj == T(0));
+    obj.store(T(1), cuda::std::memory_order_release);
+    assert(obj == T(1));
+    assert(obj.load() == T(1));
+    assert(obj.load(cuda::std::memory_order_acquire) == T(1));
+    assert(obj.exchange(T(2)) == T(1));
+    assert(obj == T(2));
+    assert(obj.exchange(T(3), cuda::std::memory_order_relaxed) == T(2));
+    assert(obj == T(3));
+    T x = obj;
+    assert(cmpxchg_weak_loop(obj, x, T(2)) == true);
+    assert(obj == T(2));
+    assert(x == T(3));
+    assert(obj.compare_exchange_weak(x, T(1)) == false);
+    assert(obj == T(2));
+    assert(x == T(2));
+    x = T(2);
+    assert(obj.compare_exchange_strong(x, T(1)) == true);
+    assert(obj == T(1));
+    assert(x == T(2));
+    assert(obj.compare_exchange_strong(x, T(0)) == false);
+    assert(obj == T(1));
+    assert(x == T(1));
+    assert((obj = T(0)) == T(0));
+    assert(obj == T(0));
+    obj = T(2*sizeof(X));
+    assert((obj += cuda::std::ptrdiff_t(3)) == T(5*sizeof(X)));
+    assert(obj == T(5*sizeof(X)));
+    assert((obj -= cuda::std::ptrdiff_t(3)) == T(2*sizeof(X)));
+    assert(obj == T(2*sizeof(X)));
+}
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__
+void test()
+{
+    do_test<A, T, Selector>();
+    do_test<volatile A, T, Selector>();
+}
+
+int main(int, char**)
+{
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    test<const cuda::std::atomic_ref<int*>, int*, local_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_system>, int*, local_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_device>, int*, local_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_block>, int*, local_memory_selector>();
+#endif
+#ifdef __CUDA_ARCH__
+    test<const cuda::std::atomic_ref<int*>, int*, shared_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_system>, int*, shared_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_device>, int*, shared_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_block>, int*, shared_memory_selector>();
+
+    test<const cuda::std::atomic_ref<int*>, int*, global_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_system>, int*, global_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_device>, int*, global_memory_selector>();
+    test<const cuda::atomic_ref<int*, cuda::thread_scope_block>, int*, global_memory_selector>();
+#endif
+  return 0;
+}

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/integral_ref.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/integral_ref.pass.cpp
@@ -1,0 +1,216 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+// template <>
+// struct atomic_ref<integral>
+// {
+//     bool is_lock_free() const volatile;
+//     bool is_lock_free() const;
+//     void store(integral desr, memory_order m = memory_order_seq_cst) volatile;
+//     void store(integral desr, memory_order m = memory_order_seq_cst);
+//     integral load(memory_order m = memory_order_seq_cst) const volatile;
+//     integral load(memory_order m = memory_order_seq_cst) const;
+//     operator integral() const volatile;
+//     operator integral() const;
+//     integral exchange(integral desr,
+//                       memory_order m = memory_order_seq_cst) volatile;
+//     integral exchange(integral desr, memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order s, memory_order f) volatile;
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order s, memory_order f);
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order s, memory_order f) volatile;
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order s, memory_order f);
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                 memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order m = memory_order_seq_cst);
+//
+//     integral
+//         fetch_add(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_add(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_sub(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_sub(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_and(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_and(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_or(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_or(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_xor(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_xor(integral op, memory_order m = memory_order_seq_cst);
+//
+//     atomic_ref() = delete;
+//     constexpr atomic_ref(integral& desr);
+//     atomic_ref(const atomic_ref&) = default;
+//     atomic_ref& operator=(const atomic_ref&) = delete;
+//     atomic_ref& operator=(const atomic_ref&) volatile = delete;
+//     integral operator=(integral desr) volatile;
+//     integral operator=(integral desr);
+//
+//     integral operator++(int) volatile;
+//     integral operator++(int);
+//     integral operator--(int) volatile;
+//     integral operator--(int);
+//     integral operator++() volatile;
+//     integral operator++();
+//     integral operator--() volatile;
+//     integral operator--();
+//     integral operator+=(integral op) volatile;
+//     integral operator+=(integral op);
+//     integral operator-=(integral op) volatile;
+//     integral operator-=(integral op);
+//     integral operator&=(integral op) volatile;
+//     integral operator&=(integral op);
+//     integral operator|=(integral op) volatile;
+//     integral operator|=(integral op);
+//     integral operator^=(integral op) volatile;
+//     integral operator^=(integral op);
+// };
+
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+
+#include <cmpxchg_loop.h>
+
+#include "test_macros.h"
+#if !defined(TEST_COMPILER_C1XX)
+  #include "placement_new.h"
+#endif
+#include "cuda_space_selector.h"
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__ __noinline__
+void do_test() {
+    Selector<T, constructor_initializer> sel;
+    T & val = *sel.construct(T(0));
+    assert(&val);
+    assert(val == T(0));
+    A obj(val);
+    assert(obj.load() == T(0));
+    bool b0 = obj.is_lock_free();
+    ((void)b0); // mark as unused
+    obj.store(T(0));
+    assert(obj.load() == T(0));
+    assert(obj == T(0));
+    obj.store(T(1), cuda::std::memory_order_release);
+    assert(obj == T(1));
+    assert(obj.load() == T(1));
+    assert(obj.load(cuda::std::memory_order_acquire) == T(1));
+    assert(obj.exchange(T(2)) == T(1));
+    assert(obj == T(2));
+    assert(obj.exchange(T(3), cuda::std::memory_order_relaxed) == T(2));
+    assert(obj == T(3));
+    T x = obj;
+    assert(cmpxchg_weak_loop(obj, x, T(2)) == true);
+    assert(obj == T(2));
+    assert(x == T(3));
+    assert(obj.compare_exchange_weak(x, T(1)) == false);
+    assert(obj == T(2));
+    assert(x == T(2));
+    x = T(2);
+    assert(obj.compare_exchange_strong(x, T(1)) == true);
+    assert(obj == T(1));
+    assert(x == T(2));
+    assert(obj.compare_exchange_strong(x, T(0)) == false);
+    assert(obj == T(1));
+    assert(x == T(1));
+    assert((obj = T(0)) == T(0));
+    assert(obj == T(0));
+    assert(obj++ == T(0));
+    assert(obj == T(1));
+    assert(++obj == T(2));
+    assert(obj == T(2));
+    assert(--obj == T(1));
+    assert(obj == T(1));
+    assert(obj-- == T(1));
+    assert(obj == T(0));
+    obj = T(2);
+    assert((obj += T(3)) == T(5));
+    assert(obj == T(5));
+    assert((obj -= T(3)) == T(2));
+    assert(obj == T(2));
+    assert((obj |= T(5)) == T(7));
+    assert(obj == T(7));
+    assert((obj &= T(0xF)) == T(7));
+    assert(obj == T(7));
+    assert((obj ^= T(0xF)) == T(8));
+    assert(obj == T(8));
+}
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__ __noinline__
+void test()
+{
+    do_test<A, T, Selector>();
+    do_test<volatile A, T, Selector>();
+}
+
+template<template<typename, cuda::thread_scope> typename Atomic, cuda::thread_scope Scope, template<typename, typename> class Selector>
+__host__ __device__
+void test_for_all_types()
+{
+    test<Atomic<int, Scope>, int, Selector>();
+    test<Atomic<unsigned int, Scope>, unsigned int, Selector>();
+    test<Atomic<long, Scope>, long, Selector>();
+    test<Atomic<unsigned long, Scope>, unsigned long, Selector>();
+    test<Atomic<long long, Scope>, long long, Selector>();
+    test<Atomic<unsigned long long, Scope>, unsigned long long, Selector>();
+#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+    test<Atomic<char32_t, Scope>, char32_t, Selector>();
+#endif  // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+    test<Atomic<int32_t, Scope>,   int32_t, Selector>();
+    test<Atomic<uint32_t, Scope>, uint32_t, Selector>();
+    test<Atomic<int64_t, Scope>,   int64_t, Selector>();
+    test<Atomic<uint64_t, Scope>, uint64_t, Selector>();
+}
+
+template<typename T, cuda::thread_scope Scope>
+using cuda_std_atomic_ref = cuda::std::atomic_ref<T>;
+
+template<typename T, cuda::thread_scope Scope>
+using cuda_atomic_ref = cuda::atomic_ref<T, Scope>;
+
+int main(int, char**)
+{
+    // this test would instantiate more cases than just the ones below
+    // but ptxas already consumes 5 GB of RAM while translating these
+    // so in the interest of not eating all memory, it's limited to the current set
+    //
+    // the per-function tests *should* cover the other codegen aspects of the
+    // code, and the cross between scopes and memory locations below should provide
+    // a *reasonable* subset of all the possible combinations to provide enough
+    // confidence that this all actually works
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    test_for_all_types<cuda_std_atomic_ref, cuda::thread_scope_system, local_memory_selector>();
+    test_for_all_types<cuda_atomic_ref, cuda::thread_scope_system, local_memory_selector>();
+#endif
+#ifdef __CUDA_ARCH__
+    test_for_all_types<cuda_std_atomic_ref, cuda::thread_scope_system, shared_memory_selector>();
+    test_for_all_types<cuda_atomic_ref, cuda::thread_scope_block, local_memory_selector>();
+
+    test_for_all_types<cuda_std_atomic_ref, cuda::thread_scope_system, local_memory_selector>();
+    test_for_all_types<cuda_atomic_ref, cuda::thread_scope_device, global_memory_selector>();
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/integral_ref_constness.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/integral_ref_constness.pass.cpp
@@ -1,0 +1,216 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
+
+// <cuda/std/atomic>
+
+// template <>
+// struct atomic_ref<integral>
+// {
+//     bool is_lock_free() const volatile;
+//     bool is_lock_free() const;
+//     void store(integral desr, memory_order m = memory_order_seq_cst) volatile;
+//     void store(integral desr, memory_order m = memory_order_seq_cst);
+//     integral load(memory_order m = memory_order_seq_cst) const volatile;
+//     integral load(memory_order m = memory_order_seq_cst) const;
+//     operator integral() const volatile;
+//     operator integral() const;
+//     integral exchange(integral desr,
+//                       memory_order m = memory_order_seq_cst) volatile;
+//     integral exchange(integral desr, memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order s, memory_order f) volatile;
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order s, memory_order f);
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order s, memory_order f) volatile;
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order s, memory_order f);
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                 memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order m = memory_order_seq_cst);
+//
+//     integral
+//         fetch_add(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_add(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_sub(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_sub(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_and(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_and(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_or(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_or(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_xor(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_xor(integral op, memory_order m = memory_order_seq_cst);
+//
+//     atomic_ref() = delete;
+//     constexpr atomic_ref(integral& desr);
+//     atomic_ref(const atomic_ref&) = default;
+//     atomic_ref& operator=(const atomic_ref&) = delete;
+//     atomic_ref& operator=(const atomic_ref&) volatile = delete;
+//     integral operator=(integral desr) volatile;
+//     integral operator=(integral desr);
+//
+//     integral operator++(int) volatile;
+//     integral operator++(int);
+//     integral operator--(int) volatile;
+//     integral operator--(int);
+//     integral operator++() volatile;
+//     integral operator++();
+//     integral operator--() volatile;
+//     integral operator--();
+//     integral operator+=(integral op) volatile;
+//     integral operator+=(integral op);
+//     integral operator-=(integral op) volatile;
+//     integral operator-=(integral op);
+//     integral operator&=(integral op) volatile;
+//     integral operator&=(integral op);
+//     integral operator|=(integral op) volatile;
+//     integral operator|=(integral op);
+//     integral operator^=(integral op) volatile;
+//     integral operator^=(integral op);
+// };
+
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+
+#include <cmpxchg_loop.h>
+
+#include "test_macros.h"
+#if !defined(TEST_COMPILER_C1XX)
+  #include "placement_new.h"
+#endif
+#include "cuda_space_selector.h"
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__ __noinline__
+void do_test() {
+    Selector<T, constructor_initializer> sel;
+    T & val = *sel.construct(T(0));
+    assert(&val);
+    assert(val == T(0));
+    A obj(val);
+    assert(obj.load() == T(0));
+    bool b0 = obj.is_lock_free();
+    ((void)b0); // mark as unused
+    obj.store(T(0));
+    assert(obj.load() == T(0));
+    assert(obj == T(0));
+    obj.store(T(1), cuda::std::memory_order_release);
+    assert(obj == T(1));
+    assert(obj.load() == T(1));
+    assert(obj.load(cuda::std::memory_order_acquire) == T(1));
+    assert(obj.exchange(T(2)) == T(1));
+    assert(obj == T(2));
+    assert(obj.exchange(T(3), cuda::std::memory_order_relaxed) == T(2));
+    assert(obj == T(3));
+    T x = obj;
+    assert(cmpxchg_weak_loop(obj, x, T(2)) == true);
+    assert(obj == T(2));
+    assert(x == T(3));
+    assert(obj.compare_exchange_weak(x, T(1)) == false);
+    assert(obj == T(2));
+    assert(x == T(2));
+    x = T(2);
+    assert(obj.compare_exchange_strong(x, T(1)) == true);
+    assert(obj == T(1));
+    assert(x == T(2));
+    assert(obj.compare_exchange_strong(x, T(0)) == false);
+    assert(obj == T(1));
+    assert(x == T(1));
+    assert((obj = T(0)) == T(0));
+    assert(obj == T(0));
+    assert(obj++ == T(0));
+    assert(obj == T(1));
+    assert(++obj == T(2));
+    assert(obj == T(2));
+    assert(--obj == T(1));
+    assert(obj == T(1));
+    assert(obj-- == T(1));
+    assert(obj == T(0));
+    obj = T(2);
+    assert((obj += T(3)) == T(5));
+    assert(obj == T(5));
+    assert((obj -= T(3)) == T(2));
+    assert(obj == T(2));
+    assert((obj |= T(5)) == T(7));
+    assert(obj == T(7));
+    assert((obj &= T(0xF)) == T(7));
+    assert(obj == T(7));
+    assert((obj ^= T(0xF)) == T(8));
+    assert(obj == T(8));
+}
+
+template <class A, class T, template<typename, typename> class Selector>
+__host__ __device__ __noinline__
+void test()
+{
+    do_test<A, T, Selector>();
+    do_test<volatile A, T, Selector>();
+}
+
+template<template<typename, cuda::thread_scope> typename Atomic, cuda::thread_scope Scope, template<typename, typename> class Selector>
+__host__ __device__
+void test_for_all_types()
+{
+    test<Atomic<int, Scope>, int, Selector>();
+    test<Atomic<unsigned int, Scope>, unsigned int, Selector>();
+    test<Atomic<long, Scope>, long, Selector>();
+    test<Atomic<unsigned long, Scope>, unsigned long, Selector>();
+    test<Atomic<long long, Scope>, long long, Selector>();
+    test<Atomic<unsigned long long, Scope>, unsigned long long, Selector>();
+#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+    test<Atomic<char32_t, Scope>, char32_t, Selector>();
+#endif  // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+    test<Atomic<int32_t, Scope>,   int32_t, Selector>();
+    test<Atomic<uint32_t, Scope>, uint32_t, Selector>();
+    test<Atomic<int64_t, Scope>,   int64_t, Selector>();
+    test<Atomic<uint64_t, Scope>, uint64_t, Selector>();
+}
+
+template<typename T, cuda::thread_scope Scope>
+using cuda_std_atomic_ref = const cuda::std::atomic_ref<T>;
+
+template<typename T, cuda::thread_scope Scope>
+using cuda_atomic_ref = const cuda::atomic_ref<T, Scope>;
+
+int main(int, char**)
+{
+    // this test would instantiate more cases than just the ones below
+    // but ptxas already consumes 5 GB of RAM while translating these
+    // so in the interest of not eating all memory, it's limited to the current set
+    //
+    // the per-function tests *should* cover the other codegen aspects of the
+    // code, and the cross between scopes and memory locations below should provide
+    // a *reasonable* subset of all the possible combinations to provide enough
+    // confidence that this all actually works
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    test_for_all_types<cuda_std_atomic_ref, cuda::thread_scope_system, local_memory_selector>();
+    test_for_all_types<cuda_atomic_ref, cuda::thread_scope_system, local_memory_selector>();
+#endif
+#ifdef __CUDA_ARCH__
+    test_for_all_types<cuda_std_atomic_ref, cuda::thread_scope_system, shared_memory_selector>();
+    test_for_all_types<cuda_atomic_ref, cuda::thread_scope_block, local_memory_selector>();
+
+    test_for_all_types<cuda_std_atomic_ref, cuda::thread_scope_system, local_memory_selector>();
+    test_for_all_types<cuda_atomic_ref, cuda::thread_scope_device, global_memory_selector>();
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/trivially_copyable.fail.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/trivially_copyable.fail.cpp
@@ -9,6 +9,9 @@
 // .fail. expects compilation to fail, but this would only fail at runtime with NVRTC
 // UNSUPPORTED: nvrtc
 
+// trivially_copyable not supported on gcc4.8
+// UNSUPPORTED: gcc-4.8
+
 // <cuda/std/atomic>
 
 // template <class T>
@@ -53,15 +56,17 @@
 #include <cuda/std/cassert>
 
 struct NotTriviallyCopyable {
-    NotTriviallyCopyable ( int i ) : i_(i) {}
-    NotTriviallyCopyable ( const NotTriviallyCopyable &rhs) : i_(rhs.i_) {}
+    __host__ __device__ NotTriviallyCopyable ( int i ) : i_(i) {}
+    __host__ __device__ NotTriviallyCopyable ( const NotTriviallyCopyable &rhs) : i_(rhs.i_) {}
     int i_;
 };
 
-template <class T, class >
+template <class T>
+__host__ __device__
 void test ( T t ) {
     cuda::std::atomic<T> t0(t);
 }
+
 
 int main(int, char**)
 {

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/trivially_copyable_ref.fail.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/trivially_copyable_ref.fail.cpp
@@ -5,13 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
-// UNSUPPORTED: windows && pre-sm-70
 
-// NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
-// clang versions. It was fixed right before the llvm 3.5 release. See PR18097.
-// XFAIL: apple-clang-6.0, clang-3.4, clang-3.3
+// .fail. expects compilation to fail, but this would only fail at runtime with NVRTC
+// UNSUPPORTED: nvrtc
+
+// trivially_copyable not supported on gcc4.8
+// UNSUPPORTED: gcc-4.8
 
 // <cuda/std/atomic>
 
@@ -55,29 +54,22 @@
 
 #include <cuda/std/atomic>
 #include <cuda/std/cassert>
-// #include <cuda/std/thread> // for thread_id
-// #include <cuda/std/chrono> // for nanoseconds
 
-#include "test_macros.h"
-
-struct TriviallyCopyable {
-    __host__ __device__
-    TriviallyCopyable ( int i ) : i_(i) {}
+struct NotTriviallyCopyable {
+    __host__ __device__ NotTriviallyCopyable ( int i ) : i_(i) {}
+    __host__ __device__ NotTriviallyCopyable ( const NotTriviallyCopyable &rhs) : i_(rhs.i_) {}
     int i_;
 };
 
 template <class T>
 __host__ __device__
 void test ( T t ) {
-    cuda::std::atomic<T> t0(t);
-    cuda::std::atomic_ref<T> t1(t);
+    cuda::std::atomic_ref<T> t0(t);
 }
 
 int main(int, char**)
 {
-    test(TriviallyCopyable(42));
-    // test(cuda::std::this_thread::get_id());
-    // test(cuda::std::chrono::nanoseconds(2));
+    test(NotTriviallyCopyable(42));
 
   return 0;
 }

--- a/.upstream-tests/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_helpers.h
+++ b/.upstream-tests/test/std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_helpers.h
@@ -78,5 +78,46 @@ struct TestEachAtomicType {
     }
 };
 
+template < template <class, template<typename, typename> class, cuda::thread_scope> class TestFunctor,
+    template<typename, typename> class Selector, cuda::thread_scope Scope
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
+    = cuda::thread_scope_system
+#endif
+>
+struct TestEachIntegralRefType {
+    __host__ __device__
+    void operator()() const {
+        TestFunctor<int, Selector, Scope>()();
+        TestFunctor<unsigned int, Selector, Scope>()();
+        TestFunctor<long, Selector, Scope>()();
+        TestFunctor<unsigned long, Selector, Scope>()();
+        TestFunctor<long long, Selector, Scope>()();
+        TestFunctor<unsigned long long, Selector, Scope>()();
+#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+        TestFunctor<char32_t, Selector, Scope>()();
+#endif
+        TestFunctor< int32_t, Selector, Scope>()();
+        TestFunctor<uint32_t, Selector, Scope>()();
+        TestFunctor< int64_t, Selector, Scope>()();
+        TestFunctor<uint64_t, Selector, Scope>()();
+    }
+};
+
+template < template <class, template<typename, typename> class, cuda::thread_scope> class TestFunctor,
+    template<typename, typename> class Selector, cuda::thread_scope Scope
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
+    = cuda::thread_scope_system
+#endif
+>
+struct TestEachAtomicRefType {
+    __host__ __device__
+    void operator()() const {
+        TestEachIntegralRefType<TestFunctor, Selector, Scope>()();
+        TestFunctor<UserAtomicType, Selector, Scope>()();
+        TestFunctor<int*, Selector, Scope>()();
+        TestFunctor<const int*, Selector, Scope>()();
+    }
+};
+
 
 #endif // ATOMIC_HELPER_H

--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -82,8 +82,8 @@ struct atomic
     : public std::__atomic_base<_Tp, _Sco>
 {
     typedef std::__atomic_base<_Tp, _Sco> __base;
-    __host__ __device__
-    atomic() noexcept : __base() {}
+
+    constexpr atomic() noexcept = default;
     __host__ __device__
     constexpr atomic(_Tp __d) noexcept : __base(__d) {}
 
@@ -114,8 +114,8 @@ struct atomic<_Tp*, _Sco>
     : public std::__atomic_base<_Tp*, _Sco>
 {
     typedef std::__atomic_base<_Tp*, _Sco> __base;
-    __host__ __device__
-    atomic() noexcept : __base() {}
+
+    constexpr atomic() noexcept = default;
     __host__ __device__
     constexpr atomic(_Tp* __d) noexcept : __base(__d) {}
 
@@ -165,6 +165,98 @@ struct atomic<_Tp*, _Sco>
     _Tp* operator-=(ptrdiff_t __op) volatile noexcept {return fetch_sub(__op) - __op;}
     __host__ __device__
     _Tp* operator-=(ptrdiff_t __op) noexcept          {return fetch_sub(__op) - __op;}
+};
+
+// atomic<T>
+
+template <class _Tp, thread_scope _Sco = thread_scope::thread_scope_system>
+struct atomic_ref
+    : public std::__atomic_base_ref<_Tp, _Sco>
+{
+    typedef std::__atomic_base_ref<_Tp, _Sco> __base;
+
+    __host__ __device__
+    constexpr atomic_ref(_Tp& __d) noexcept : __base(__d) {}
+
+    __host__ __device__
+    _Tp operator=(_Tp __d) const volatile noexcept
+        {__base::store(__d); return __d;}
+    __host__ __device__
+    _Tp operator=(_Tp __d) const noexcept
+        {__base::store(__d); return __d;}
+
+    __host__ __device__
+    _Tp fetch_max(const _Tp & __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
+    {
+        return std::__detail::__cxx_atomic_fetch_max(&this->__a_, __op, __m);
+    }
+
+    __host__ __device__
+    _Tp fetch_min(const _Tp & __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
+    {
+        return std::__detail::__cxx_atomic_fetch_min(&this->__a_, __op, __m);
+    }
+};
+
+// atomic<T*>
+
+template <class _Tp, thread_scope _Sco>
+struct atomic_ref<_Tp*, _Sco>
+    : public std::__atomic_base_ref<_Tp*, _Sco>
+{
+    typedef std::__atomic_base_ref<_Tp*, _Sco> __base;
+
+    __host__ __device__
+    constexpr atomic_ref(_Tp*& __d) noexcept : __base(__d) {}
+
+    __host__ __device__
+    _Tp* operator=(_Tp* __d) const volatile noexcept
+        {__base::store(__d); return __d;}
+    __host__ __device__
+    _Tp* operator=(_Tp* __d) const noexcept
+        {__base::store(__d); return __d;}
+
+    __host__ __device__
+    _Tp* fetch_add(ptrdiff_t __op,
+                   memory_order __m = memory_order_seq_cst) const volatile noexcept
+        {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
+    __host__ __device__
+    _Tp* fetch_add(ptrdiff_t __op,
+                   memory_order __m = memory_order_seq_cst) const noexcept
+        {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
+    __host__ __device__
+    _Tp* fetch_sub(ptrdiff_t __op,
+                   memory_order __m = memory_order_seq_cst) const volatile noexcept
+        {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
+    __host__ __device__
+    _Tp* fetch_sub(ptrdiff_t __op,
+                   memory_order __m = memory_order_seq_cst) const noexcept
+        {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
+
+    __host__ __device__
+    _Tp* operator++(int) const volatile noexcept            {return fetch_add(1);}
+    __host__ __device__
+    _Tp* operator++(int) const noexcept                     {return fetch_add(1);}
+    __host__ __device__
+    _Tp* operator--(int) const volatile noexcept            {return fetch_sub(1);}
+    __host__ __device__
+    _Tp* operator--(int) const noexcept                     {return fetch_sub(1);}
+    __host__ __device__
+    _Tp* operator++() const volatile noexcept               {return fetch_add(1) + 1;}
+    __host__ __device__
+    _Tp* operator++() const noexcept                        {return fetch_add(1) + 1;}
+    __host__ __device__
+    _Tp* operator--() const volatile noexcept               {return fetch_sub(1) - 1;}
+    __host__ __device__
+    _Tp* operator--() const noexcept                        {return fetch_sub(1) - 1;}
+    __host__ __device__
+    _Tp* operator+=(ptrdiff_t __op) const volatile noexcept {return fetch_add(__op) + __op;}
+    __host__ __device__
+    _Tp* operator+=(ptrdiff_t __op) const noexcept          {return fetch_add(__op) + __op;}
+    __host__ __device__
+    _Tp* operator-=(ptrdiff_t __op) const volatile noexcept {return fetch_sub(__op) - __op;}
+    __host__ __device__
+    _Tp* operator-=(ptrdiff_t __op) const noexcept          {return fetch_sub(__op) - __op;}
 };
 
 inline __host__ __device__ void atomic_thread_fence(memory_order __m, thread_scope _Scope = thread_scope::thread_scope_system) {

--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -167,7 +167,7 @@ struct atomic<_Tp*, _Sco>
     _Tp* operator-=(ptrdiff_t __op) noexcept          {return fetch_sub(__op) - __op;}
 };
 
-// atomic<T>
+// atomic_ref<T>
 
 template <class _Tp, thread_scope _Sco = thread_scope::thread_scope_system>
 struct atomic_ref
@@ -198,7 +198,7 @@ struct atomic_ref
     }
 };
 
-// atomic<T*>
+// atomic_ref<T*>
 
 template <class _Tp, thread_scope _Sco>
 struct atomic_ref<_Tp*, _Sco>

--- a/include/cuda/std/detail/libcxx/include/atomic
+++ b/include/cuda/std/detail/libcxx/include/atomic
@@ -697,6 +697,7 @@ namespace __detail {
 }
 
 using __detail::__cxx_atomic_base_impl;
+using __detail::__cxx_atomic_ref_base_impl;
 using __detail::__cxx_atomic_thread_fence;
 using __detail::__cxx_atomic_signal_fence;
 using __detail::__cxx_atomic_load;
@@ -753,6 +754,8 @@ struct __cxx_atomic_lock_impl {
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
   __cxx_atomic_lock_impl(_Tp value) _NOEXCEPT
     : __a_value(value), __a_lock(0) {}
+
+  __cxx_atomic_lock_impl(const __cxx_atomic_lock_impl&) _NOEXCEPT = default;
 
   _Tp __a_value;
   mutable __cxx_atomic_base_impl<_LIBCUDACXX_ATOMIC_FLAG_TYPE, _Sco> __a_lock;
@@ -1054,19 +1057,11 @@ template <typename _Tp, int _Sco,
           typename _Base = __cxx_atomic_base_impl<_Tp, _Sco> >
 #endif //_LIBCUDACXX_ATOMIC_ONLY_USE_BUILTINS
 struct __cxx_atomic_impl : public _Base {
-
-#if _GNUC_VER >= 501
-    static_assert(is_trivially_copyable<_Tp>::value,
-      "std::atomic<Tp> requires that 'Tp' be a trivially copyable type");
-#endif
-
-#ifdef _LIBCUDACXX_CXX03_LANG
-  _LIBCUDACXX_INLINE_VISIBILITY
-#endif
   __cxx_atomic_impl() _NOEXCEPT _LIBCUDACXX_DEFAULT
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit __cxx_atomic_impl(_Tp value) _NOEXCEPT
     : _Base(value) {}
 };
+
 
 template<int _Sco, typename _Tp = int>
 _LIBCUDACXX_INLINE_VISIBILITY
@@ -1075,6 +1070,9 @@ __cxx_atomic_impl<_Tp, _Sco>* __cxx_atomic_rebind(_Tp* __inst) {
     static_assert(alignof(__cxx_atomic_impl<_Tp, _Sco>) == alignof(_Tp),"");
     return (__cxx_atomic_impl<_Tp, _Sco>*)__inst;
 }
+
+template <typename _Tp, int _Sco>
+using __cxx_atomic_ref_impl = __cxx_atomic_ref_base_impl<_Tp, _Sco>;
 
 #ifdef _LIBCUDACXX_HAS_NO_THREAD_CONTENTION_TABLE
 
@@ -1241,12 +1239,14 @@ _LIBCUDACXX_INLINE_VISIBILITY void __cxx_atomic_wait(__cxx_atomic_impl<_Tp, _Sco
         __cxx_atomic_try_wait_slow(__a, __val, __order);
 }
 
-// general atomic<T>
-
-template <class _Tp, int _Sco = 0, bool = is_integral<_Tp>::value && !is_same<_Tp, bool>::value>
-struct __atomic_base  // false
-{
+// general atomic<T>/atomic_ref<T>
+template <class _Tp, int _Sco = 0, bool = is_integral<_Tp>() && !is_same<_Tp, bool>()>
+struct __atomic_base {
     mutable __cxx_atomic_impl<_Tp, _Sco> __a_;
+
+    __atomic_base() = default;
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    __atomic_base(const _Tp& __a) _NOEXCEPT : __a_(__a) {}
 
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
     static _LIBCUDACXX_CONSTEXPR bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(decltype(__a_)), 0);
@@ -1357,48 +1357,135 @@ struct __atomic_base  // false
         {__cxx_atomic_notify_all(&__a_);}
     _LIBCUDACXX_INLINE_VISIBILITY void notify_all() _NOEXCEPT
         {__cxx_atomic_notify_all(&__a_);}
-
-#ifdef _LIBCUDACXX_CXX03_LANG
-    _LIBCUDACXX_INLINE_VISIBILITY
-#endif
-    __atomic_base() _NOEXCEPT _LIBCUDACXX_DEFAULT
-
-    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
-    __atomic_base(_Tp __d) _NOEXCEPT : __a_(__d) {}
-
-#ifndef _LIBCUDACXX_CXX03_LANG
-    __atomic_base(const __atomic_base&) = delete;
-    __atomic_base& operator=(const __atomic_base&) = delete;
-    __atomic_base& operator=(const __atomic_base&) volatile = delete;
-#else
-private:
-    _LIBCUDACXX_INLINE_VISIBILITY
-    __atomic_base(const __atomic_base&);
-    _LIBCUDACXX_INLINE_VISIBILITY
-    __atomic_base& operator=(const __atomic_base&);
-    _LIBCUDACXX_INLINE_VISIBILITY
-    __atomic_base& operator=(const __atomic_base&) volatile;
-#endif
 };
 
+template <class _Tp, int _Sco = 0, bool = is_integral<_Tp>() && !is_same<_Tp, bool>()>
+struct __atomic_base_ref {
+    mutable __cxx_atomic_ref_impl<_Tp, _Sco> __a_;
+
+    __atomic_base_ref() = default;
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    __atomic_base_ref(_Tp& __a) _NOEXCEPT : __a_(__a) {}
+
 #if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
-template <class _Tp, int _Sco, bool __b>
-_LIBCUDACXX_CONSTEXPR bool __atomic_base<_Tp, _Sco, __b>::is_always_lock_free;
-#endif
+    static _LIBCUDACXX_CONSTEXPR bool is_always_lock_free = _LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE(sizeof(decltype(__a_)), 0);
+#endif // defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
 
-// atomic<Integral>
 
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool is_lock_free() const volatile _NOEXCEPT
+        {return __cxx_atomic_is_lock_free(sizeof(_Tp));}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool is_lock_free() const _NOEXCEPT
+        {return static_cast<__atomic_base_ref const volatile*>(this)->is_lock_free();}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    void store(_Tp __d, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+      _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
+        {__cxx_atomic_store(&__a_, __d, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    void store(_Tp __d, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+      _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)
+        {__cxx_atomic_store(&__a_, __d, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp load(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+      _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
+        {return __cxx_atomic_load(&__a_, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp load(memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+      _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)
+        {return __cxx_atomic_load(&__a_, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    operator _Tp() const volatile _NOEXCEPT {return load();}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    operator _Tp() const _NOEXCEPT          {return load();}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {return __cxx_atomic_exchange(&__a_, __d, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {return __cxx_atomic_exchange(&__a_, __d, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_weak(_Tp& __e, _Tp __d,
+                               memory_order __s, memory_order __f) const volatile _NOEXCEPT
+      _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
+        {return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __s, __f);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_weak(_Tp& __e, _Tp __d,
+                               memory_order __s, memory_order __f) const _NOEXCEPT
+      _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
+        {return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __s, __f);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_strong(_Tp& __e, _Tp __d,
+                                 memory_order __s, memory_order __f) const volatile _NOEXCEPT
+      _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
+        {return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __s, __f);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_strong(_Tp& __e, _Tp __d,
+                                 memory_order __s, memory_order __f) const _NOEXCEPT
+      _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)
+        {return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __s, __f);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_weak(_Tp& __e, _Tp __d,
+                              memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+        if (memory_order_acq_rel == __m)
+            return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __m, memory_order_acquire);
+        else if (memory_order_release == __m)
+            return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __m, memory_order_relaxed);
+        else
+            return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __m, __m);
+    }
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_weak(_Tp& __e, _Tp __d,
+                               memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
+        if(memory_order_acq_rel == __m)
+            return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __m, memory_order_acquire);
+        else if(memory_order_release == __m)
+            return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __m, memory_order_relaxed);
+        else
+            return __cxx_atomic_compare_exchange_weak(&__a_, &__e, __d, __m, __m);
+    }
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_strong(_Tp& __e, _Tp __d,
+                              memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+        if (memory_order_acq_rel == __m)
+            return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __m, memory_order_acquire);
+        else if (memory_order_release == __m)
+            return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __m, memory_order_relaxed);
+        else
+            return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __m, __m);
+    }
+    _LIBCUDACXX_INLINE_VISIBILITY
+    bool compare_exchange_strong(_Tp& __e, _Tp __d,
+                                 memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
+        if (memory_order_acq_rel == __m)
+            return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __m, memory_order_acquire);
+        else if (memory_order_release == __m)
+            return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __m, memory_order_relaxed);
+        else
+            return __cxx_atomic_compare_exchange_strong(&__a_, &__e, __d, __m, __m);
+    }
+
+    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {__cxx_atomic_wait(&__a_, __v, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {__cxx_atomic_wait(&__a_, __v, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() const volatile _NOEXCEPT
+        {__cxx_atomic_notify_one(&__a_);}
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_one() const _NOEXCEPT
+        {__cxx_atomic_notify_one(&__a_);}
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() const volatile _NOEXCEPT
+        {__cxx_atomic_notify_all(&__a_);}
+    _LIBCUDACXX_INLINE_VISIBILITY void notify_all() const _NOEXCEPT
+        {__cxx_atomic_notify_all(&__a_);}
+};
+
+// atomic/atomic_ref<integral>
 template <class _Tp, int _Sco>
-struct __atomic_base<_Tp, _Sco, true>
-    : public __atomic_base<_Tp, _Sco, false>
-{
-    typedef __atomic_base<_Tp, _Sco, false> __base;
-#ifdef _LIBCUDACXX_CXX03_LANG
-    _LIBCUDACXX_INLINE_VISIBILITY
-#endif
-    __atomic_base() _NOEXCEPT _LIBCUDACXX_DEFAULT
-    _LIBCUDACXX_INLINE_VISIBILITY
-    _LIBCUDACXX_CONSTEXPR __atomic_base(_Tp __d) _NOEXCEPT : __base(__d) {}
+struct __atomic_base<_Tp, _Sco, true> : public __atomic_base<_Tp, _Sco, false> {
+    __atomic_base() = default;
+
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    __atomic_base(const _Tp& __a) _NOEXCEPT : __atomic_base<_Tp, _Sco, false>(__a) {}
 
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
@@ -1469,6 +1556,90 @@ struct __atomic_base<_Tp, _Sco, true>
     _Tp operator^=(_Tp __op) _NOEXCEPT          {return fetch_xor(__op) ^ __op;}
 };
 
+template <class _Tp, int _Sco>
+struct __atomic_base_ref<_Tp, _Sco, true> : public __atomic_base_ref<_Tp, _Sco, false> {
+    __atomic_base_ref() = default;
+
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+    __atomic_base_ref(_Tp& __a) _NOEXCEPT : __atomic_base_ref<_Tp, _Sco, false>(__a) {}
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_and(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {return __cxx_atomic_fetch_and(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_or(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {return __cxx_atomic_fetch_or(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_xor(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+        {return __cxx_atomic_fetch_xor(&this->__a_, __op, __m);}
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator++(int) const volatile _NOEXCEPT      {return fetch_add(_Tp(1));}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator++(int) const _NOEXCEPT               {return fetch_add(_Tp(1));}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator--(int) const volatile _NOEXCEPT      {return fetch_sub(_Tp(1));}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator--(int) const _NOEXCEPT               {return fetch_sub(_Tp(1));}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator++() const volatile _NOEXCEPT         {return fetch_add(_Tp(1)) + _Tp(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator++() const _NOEXCEPT                  {return fetch_add(_Tp(1)) + _Tp(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator--() const volatile _NOEXCEPT         {return fetch_sub(_Tp(1)) - _Tp(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator--() const _NOEXCEPT                  {return fetch_sub(_Tp(1)) - _Tp(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator+=(_Tp __op) const volatile _NOEXCEPT {return fetch_add(__op) + __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator+=(_Tp __op) const _NOEXCEPT          {return fetch_add(__op) + __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator-=(_Tp __op) const volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator-=(_Tp __op) const _NOEXCEPT          {return fetch_sub(__op) - __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator&=(_Tp __op) const volatile _NOEXCEPT {return fetch_and(__op) & __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator&=(_Tp __op) const _NOEXCEPT          {return fetch_and(__op) & __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator|=(_Tp __op) const volatile _NOEXCEPT {return fetch_or(__op) | __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator|=(_Tp __op) const _NOEXCEPT          {return fetch_or(__op) | __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator^=(_Tp __op) const volatile _NOEXCEPT {return fetch_xor(__op) ^ __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator^=(_Tp __op) const _NOEXCEPT          {return fetch_xor(__op) ^ __op;}
+};
+
+#if defined(_LIBCUDACXX_ATOMIC_ALWAYS_LOCK_FREE)
+template <class _Tp, int _Sco, bool _Integral>
+_LIBCUDACXX_CONSTEXPR bool __atomic_base<_Tp, _Sco, _Integral>::is_always_lock_free;
+
+template <class _Tp, int _Sco, bool _Integral>
+_LIBCUDACXX_CONSTEXPR bool __atomic_base_ref<_Tp, _Sco, _Integral>::is_always_lock_free;
+#endif
+
 // atomic<T>
 
 template <class _Tp>
@@ -1519,14 +1690,16 @@ struct atomic<_Tp*>
                                                                         volatile _NOEXCEPT
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
+                                                                        _NOEXCEPT
         {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
                                                                         volatile _NOEXCEPT
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
     _LIBCUDACXX_INLINE_VISIBILITY
-    _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT
+    _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
+                                                                        _NOEXCEPT
         {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
 
     _LIBCUDACXX_INLINE_VISIBILITY
@@ -1553,6 +1726,98 @@ struct atomic<_Tp*>
     _Tp* operator-=(ptrdiff_t __op) volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
     _LIBCUDACXX_INLINE_VISIBILITY
     _Tp* operator-=(ptrdiff_t __op) _NOEXCEPT          {return fetch_sub(__op) - __op;}
+};
+
+// atomic_ref<T>
+
+template <class _Tp>
+ struct atomic_ref
+    : public __atomic_base_ref<_Tp>
+{
+    typedef __atomic_base_ref<_Tp> __base;
+    using value_type = _Tp;
+
+    static constexpr size_t required_alignment = sizeof(_Tp);
+
+    static constexpr bool is_always_lock_free = sizeof(_Tp) <= 8;
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    explicit atomic_ref(_Tp& __ref) : __base(__ref) {}
+
+    atomic_ref(const atomic_ref&) noexcept = default;
+    atomic_ref& operator=(const atomic_ref&) = delete;
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator=(_Tp __v) const noexcept {__base::store(__v); return __v;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp operator=(_Tp __v) const volatile noexcept {__base::store(__v); return __v;}
+};
+
+// atomic_ref<T*>
+
+template <class _Tp>
+ struct atomic_ref<_Tp*>
+    : public __atomic_base_ref<_Tp*>
+{
+    typedef __atomic_base_ref<_Tp*> __base;
+    using value_type = _Tp*;
+
+    static constexpr size_t required_alignment = sizeof(_Tp*);
+
+    static constexpr bool is_always_lock_free = sizeof(_Tp*) <= 8;
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    explicit atomic_ref(_Tp*& __ref) : __base(__ref) {}
+
+    atomic_ref(const atomic_ref&) noexcept = default;
+    atomic_ref& operator=(const atomic_ref&) = delete;
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator=(_Tp* __v) const noexcept {__base::store(__v); return __v;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator=(_Tp* __v) const volatile noexcept {__base::store(__v); return __v;}
+
+        _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
+                                                                        const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
+                                                                        const _NOEXCEPT
+        {return __cxx_atomic_fetch_add(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
+                                                                        const volatile _NOEXCEPT
+        {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst)
+                                                                        const _NOEXCEPT
+        {return __cxx_atomic_fetch_sub(&this->__a_, __op, __m);}
+
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator++(int) const volatile _NOEXCEPT            {return fetch_add(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator++(int) const _NOEXCEPT                     {return fetch_add(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator--(int) const volatile _NOEXCEPT            {return fetch_sub(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator--(int) const _NOEXCEPT                     {return fetch_sub(1);}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator++() const volatile _NOEXCEPT               {return fetch_add(1) + 1;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator++() const _NOEXCEPT                        {return fetch_add(1) + 1;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator--() const volatile _NOEXCEPT               {return fetch_sub(1) - 1;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator--() const _NOEXCEPT                        {return fetch_sub(1) - 1;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator+=(ptrdiff_t __op) const volatile _NOEXCEPT {return fetch_add(__op) + __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator+=(ptrdiff_t __op) const _NOEXCEPT          {return fetch_add(__op) + __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator-=(ptrdiff_t __op) const volatile _NOEXCEPT {return fetch_sub(__op) - __op;}
+    _LIBCUDACXX_INLINE_VISIBILITY
+    _Tp* operator-=(ptrdiff_t __op) const _NOEXCEPT          {return fetch_sub(__op) - __op;}
 };
 
 // atomic_is_lock_free

--- a/include/cuda/std/detail/libcxx/include/support/atomic/atomic_cuda.h
+++ b/include/cuda/std/detail/libcxx/include/support/atomic/atomic_cuda.h
@@ -93,45 +93,53 @@ inline
     )
 }
 
-template <typename _Tp, int _Sco, bool _Ref>
-using __cxx_atomic_base_heterogeneous_storage
-            = typename conditional<_Ref,
-                    __host::__cxx_atomic_ref_base_impl<_Tp, _Sco>,
-                    __host::__cxx_atomic_base_impl<_Tp, _Sco> >::type;
-
-
 template <typename _Tp, int _Sco, bool _Ref = false>
 struct __cxx_atomic_base_heterogeneous_impl {
     __cxx_atomic_base_heterogeneous_impl() noexcept = default;
+
     _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
       __cxx_atomic_base_heterogeneous_impl(_Tp __value) : __a_value(__value) {
     }
 
-    __cxx_atomic_base_heterogeneous_storage<_Tp, _Sco, _Ref> __a_value;
+    __host::__cxx_atomic_base_impl<_Tp, _Sco> __a_value;
+};
+
+template <typename _Tp, int _Sco>
+struct __cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, true> {
+    __cxx_atomic_base_heterogeneous_impl() noexcept = default;
+
+    static_assert(sizeof(_Tp) >= 4, "atomic_ref does not support 1 or 2 byte types");
+    static_assert(sizeof(_Tp) <= 8, "atomic_ref does not support types larger than 8 bytes");
+
+    _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
+      __cxx_atomic_base_heterogeneous_impl(_Tp& __value) : __a_value(__value) {
+    }
+
+    __host::__cxx_atomic_ref_base_impl<_Tp, _Sco> __a_value;
 };
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> * __a) _NOEXCEPT {
-  return __cxx_atomic_base_unwrap(&__a->__a_value);
+  return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> volatile* __a) _NOEXCEPT {
-  return __cxx_atomic_base_unwrap(&__a->__a_value);
+  return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 const _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const* __a) _NOEXCEPT {
-  return __cxx_atomic_base_unwrap(&__a->__a_value);
+  return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco, bool _Ref>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 const volatile _Tp* __cxx_get_underlying_device_atomic(__cxx_atomic_base_heterogeneous_impl<_Tp, _Sco, _Ref> const volatile* __a) _NOEXCEPT {
-  return __cxx_atomic_base_unwrap(&__a->__a_value);
+  return __cxx_get_underlying_atomic(&__a->__a_value);
 }
 
 template <typename _Tp, int _Sco>

--- a/include/cuda/std/detail/libcxx/include/support/atomic/cxx_atomic.h
+++ b/include/cuda/std/detail/libcxx/include/support/atomic/cxx_atomic.h
@@ -14,7 +14,15 @@
 template <typename _Tp, int _Sco>
 struct __cxx_atomic_base_impl {
   using __underlying_t = _Tp;
+  using __temporary_t = __cxx_atomic_base_impl<_Tp, _Sco>;
+  using __wrap_t = __cxx_atomic_base_impl<_Tp, _Sco>;
+
   static constexpr int __sco = _Sco;
+
+#if !defined(_LIBCUDACXX_COMPILER_GCC) || (__GNUC__ >= 5)
+  static_assert(is_trivially_copyable<_Tp>::value,
+    "std::atomic<Tp> requires that 'Tp' be a trivially copyable type");
+#endif
 
   _LIBCUDACXX_CONSTEXPR
   __cxx_atomic_base_impl() _NOEXCEPT = default;
@@ -30,35 +38,60 @@ _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> * __a) _NOEXCEPT {
   return &__a->__a_value;
 }
-
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
   return &__a->__a_value;
 }
-
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
   return &__a->__a_value;
 }
-
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
   return &__a->__a_value;
 }
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+__cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco>* __a) _NOEXCEPT {
+  return __a;
+}
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
+  return __a;
+}
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+const __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
+  return __a;
+}
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+const volatile __cxx_atomic_base_impl<_Tp, _Sco>* __cxx_atomic_unwrap(__cxx_atomic_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
+  return __a;
+}
 
 template <typename _Tp, int _Sco>
 struct __cxx_atomic_ref_base_impl {
   using __underlying_t = _Tp;
+  using __temporary_t = _Tp;
+  using __wrap_t = _Tp;
+
   static constexpr int __sco = _Sco;
 
+#if !defined(_LIBCUDACXX_COMPILER_GCC) || (__GNUC__ >= 5)
+  static_assert(is_trivially_copyable<_Tp>::value,
+    "std::atomic_ref<Tp> requires that 'Tp' be a trivially copyable type");
+#endif
+
   _LIBCUDACXX_CONSTEXPR
-  __cxx_atomic_ref_base_impl() _NOEXCEPT = default;
+  __cxx_atomic_ref_base_impl() _NOEXCEPT = delete;
 
   _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR explicit
-  __cxx_atomic_ref_base_impl(_Tp value) _NOEXCEPT : __a_value(value) {}
+  __cxx_atomic_ref_base_impl(_Tp& value) _NOEXCEPT : __a_value(&value) {}
 
   _Tp* __a_value;
 };
@@ -68,28 +101,57 @@ _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) _NOEXCEPT {
   return __a->__a_value;
 }
-
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
   return __a->__a_value;
 }
-
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 const _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
   return __a->__a_value;
 }
-
 template <typename _Tp, int _Sco>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
 const volatile _Tp* __cxx_get_underlying_atomic(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
   return __a->__a_value;
 }
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco>* __a) _NOEXCEPT {
+  return __cxx_get_underlying_atomic(__a);
+}
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> volatile* __a) _NOEXCEPT {
+  return __cxx_get_underlying_atomic(__a);
+}
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+const _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const* __a) _NOEXCEPT {
+  return __cxx_get_underlying_atomic(__a);
+}
+template <typename _Tp, int _Sco>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+const volatile _Tp* __cxx_atomic_unwrap(__cxx_atomic_ref_base_impl<_Tp, _Sco> const volatile* __a) _NOEXCEPT {
+  return __cxx_get_underlying_atomic(__a);
+}
 
 template <typename _Tp>
-_LIBCUDACXX_INLINE_VISIBILITY auto __cxx_atomic_base_unwrap(_Tp* __a) _NOEXCEPT -> decltype(__cxx_get_underlying_atomic(__a)) {
-  return __cxx_get_underlying_atomic(__a);
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+_Tp* __cxx_get_underlying_atomic(_Tp* __a) _NOEXCEPT {
+  return __a;
+}
+
+template <typename _Tp, typename _Up>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+auto __cxx_atomic_wrap_to_base(_Tp*, _Up __val) _NOEXCEPT -> typename _Tp::__wrap_t {
+  return typename _Tp::__wrap_t(__val);
+}
+template <typename _Tp>
+_LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR
+auto __cxx_atomic_base_temporary(_Tp*) _NOEXCEPT -> typename _Tp::__temporary_t {
+  return typename _Tp::__temporary_t();
 }
 
 template <typename _Tp>

--- a/libcxx/test/std/atomics/atomics.types.generic/address_ref.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/address_ref.pass.cpp
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads
+//  ... test case crashes clang.
+
+// <atomic>
+
+// template <class T>
+// struct atomic<T*>
+// {
+//     bool is_lock_free() const volatile;
+//     bool is_lock_free() const;
+//     void store(T* desr, memory_order m = memory_order_seq_cst) volatile;
+//     void store(T* desr, memory_order m = memory_order_seq_cst);
+//     T* load(memory_order m = memory_order_seq_cst) const volatile;
+//     T* load(memory_order m = memory_order_seq_cst) const;
+//     operator T*() const volatile;
+//     operator T*() const;
+//     T* exchange(T* desr, memory_order m = memory_order_seq_cst) volatile;
+//     T* exchange(T* desr, memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order s, memory_order f) volatile;
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order s, memory_order f);
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order s, memory_order f) volatile;
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order s, memory_order f);
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_weak(T*& expc, T* desr,
+//                                memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                 memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_strong(T*& expc, T* desr,
+//                                  memory_order m = memory_order_seq_cst);
+//     T* fetch_add(ptrdiff_t op, memory_order m = memory_order_seq_cst) volatile;
+//     T* fetch_add(ptrdiff_t op, memory_order m = memory_order_seq_cst);
+//     T* fetch_sub(ptrdiff_t op, memory_order m = memory_order_seq_cst) volatile;
+//     T* fetch_sub(ptrdiff_t op, memory_order m = memory_order_seq_cst);
+//
+//     atomic() = default;
+//     constexpr atomic(T* desr);
+//     atomic(const atomic&) = delete;
+//     atomic& operator=(const atomic&) = delete;
+//     atomic& operator=(const atomic&) volatile = delete;
+//
+//     T* operator=(T*) volatile;
+//     T* operator=(T*);
+//     T* operator++(int) volatile;
+//     T* operator++(int);
+//     T* operator--(int) volatile;
+//     T* operator--(int);
+//     T* operator++() volatile;
+//     T* operator++();
+//     T* operator--() volatile;
+//     T* operator--();
+//     T* operator+=(ptrdiff_t op) volatile;
+//     T* operator+=(ptrdiff_t op);
+//     T* operator-=(ptrdiff_t op) volatile;
+//     T* operator-=(ptrdiff_t op);
+// };
+
+#include <atomic>
+#include <new>
+#include <type_traits>
+#include <cassert>
+
+#include <cmpxchg_loop.h>
+
+#include "test_macros.h"
+
+template <class A, class T>
+void
+do_test()
+{
+    typedef typename std::remove_pointer<T>::type X;
+    T val(0);
+    A obj(val);
+    bool b0 = obj.is_lock_free();
+    ((void)b0); // mark as unused
+    assert(obj == T(0));
+    obj.store(T(1), std::memory_order_release);
+    assert(obj == T(1));
+    assert(obj.load() == T(1));
+    assert(obj.load(std::memory_order_acquire) == T(1));
+    assert(obj.exchange(T(2)) == T(1));
+    assert(obj == T(2));
+    assert(obj.exchange(T(3), std::memory_order_relaxed) == T(2));
+    assert(obj == T(3));
+    T x = obj;
+    assert(cmpxchg_weak_loop(obj, x, T(2)) == true);
+    assert(obj == T(2));
+    assert(x == T(3));
+    assert(obj.compare_exchange_weak(x, T(1)) == false);
+    assert(obj == T(2));
+    assert(x == T(2));
+    x = T(2);
+    assert(obj.compare_exchange_strong(x, T(1)) == true);
+    assert(obj == T(1));
+    assert(x == T(2));
+    assert(obj.compare_exchange_strong(x, T(0)) == false);
+    assert(obj == T(1));
+    assert(x == T(1));
+    assert((obj = T(0)) == T(0));
+    assert(obj == T(0));
+    obj = T(2*sizeof(X));
+    assert((obj += std::ptrdiff_t(3)) == T(5*sizeof(X)));
+    assert(obj == T(5*sizeof(X)));
+    assert((obj -= std::ptrdiff_t(3)) == T(2*sizeof(X)));
+    assert(obj == T(2*sizeof(X)));
+}
+
+template <class A, class T>
+void test()
+{
+    do_test<A, T>();
+    do_test<volatile A, T>();
+    do_test<const A, T>();
+    do_test<const volatile A, T>();
+}
+
+int main(int, char**)
+{
+    test<std::atomic_ref<int*>, int*>();
+
+  return 0;
+}

--- a/libcxx/test/std/atomics/atomics.types.generic/integral_ref.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/integral_ref.pass.cpp
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+
+// <atomic>
+
+// template <>
+// struct atomic_ref<integral>
+// {
+//     bool is_lock_free() const volatile;
+//     bool is_lock_free() const;
+//     void store(integral desr, memory_order m = memory_order_seq_cst) volatile;
+//     void store(integral desr, memory_order m = memory_order_seq_cst);
+//     integral load(memory_order m = memory_order_seq_cst) const volatile;
+//     integral load(memory_order m = memory_order_seq_cst) const;
+//     operator integral() const volatile;
+//     operator integral() const;
+//     integral exchange(integral desr,
+//                       memory_order m = memory_order_seq_cst) volatile;
+//     integral exchange(integral desr, memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order s, memory_order f) volatile;
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order s, memory_order f);
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order s, memory_order f) volatile;
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order s, memory_order f);
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_weak(integral& expc, integral desr,
+//                                memory_order m = memory_order_seq_cst);
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                 memory_order m = memory_order_seq_cst) volatile;
+//     bool compare_exchange_strong(integral& expc, integral desr,
+//                                  memory_order m = memory_order_seq_cst);
+//
+//     integral
+//         fetch_add(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_add(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_sub(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_sub(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_and(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_and(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_or(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_or(integral op, memory_order m = memory_order_seq_cst);
+//     integral
+//         fetch_xor(integral op, memory_order m = memory_order_seq_cst) volatile;
+//     integral fetch_xor(integral op, memory_order m = memory_order_seq_cst);
+//
+//     atomic_ref() = delete;
+//     constexpr atomic_ref(integral& desr);
+//     atomic_ref(const atomic_ref&) = default;
+//     atomic_ref& operator=(const atomic_ref&) = delete;
+//     atomic_ref& operator=(const atomic_ref&) volatile = delete;
+//     integral operator=(integral desr) volatile;
+//     integral operator=(integral desr);
+//
+//     integral operator++(int) volatile;
+//     integral operator++(int);
+//     integral operator--(int) volatile;
+//     integral operator--(int);
+//     integral operator++() volatile;
+//     integral operator++();
+//     integral operator--() volatile;
+//     integral operator--();
+//     integral operator+=(integral op) volatile;
+//     integral operator+=(integral op);
+//     integral operator-=(integral op) volatile;
+//     integral operator-=(integral op);
+//     integral operator&=(integral op) volatile;
+//     integral operator&=(integral op);
+//     integral operator|=(integral op) volatile;
+//     integral operator|=(integral op);
+//     integral operator^=(integral op) volatile;
+//     integral operator^=(integral op);
+// };
+
+#include <atomic>
+#include <cassert>
+
+#include <cmpxchg_loop.h>
+
+#include "test_macros.h"
+
+template <class A, class T>
+void do_test() {
+    T val(0);
+    assert(&val);
+    assert(val == T(0));
+    A obj(val);
+    assert(obj.load() == T(0));
+    bool b0 = obj.is_lock_free();
+    ((void)b0); // mark as unused
+    obj.store(T(0));
+    assert(obj.load() == T(0));
+    assert(obj == T(0));
+    obj.store(T(1), std::memory_order_release);
+    assert(obj == T(1));
+    assert(obj.load() == T(1));
+    assert(obj.load(std::memory_order_acquire) == T(1));
+    assert(obj.exchange(T(2)) == T(1));
+    assert(obj == T(2));
+    assert(obj.exchange(T(3), std::memory_order_relaxed) == T(2));
+    assert(obj == T(3));
+    T x = obj;
+    assert(cmpxchg_weak_loop(obj, x, T(2)) == true);
+    assert(obj == T(2));
+    assert(x == T(3));
+    assert(obj.compare_exchange_weak(x, T(1)) == false);
+    assert(obj == T(2));
+    assert(x == T(2));
+    x = T(2);
+    assert(obj.compare_exchange_strong(x, T(1)) == true);
+    assert(obj == T(1));
+    assert(x == T(2));
+    assert(obj.compare_exchange_strong(x, T(0)) == false);
+    assert(obj == T(1));
+    assert(x == T(1));
+    assert((obj = T(0)) == T(0));
+    assert(obj == T(0));
+    assert(obj++ == T(0));
+    assert(obj == T(1));
+    assert(++obj == T(2));
+    assert(obj == T(2));
+    assert(--obj == T(1));
+    assert(obj == T(1));
+    assert(obj-- == T(1));
+    assert(obj == T(0));
+    obj = T(2);
+    assert((obj += T(3)) == T(5));
+    assert(obj == T(5));
+    assert((obj -= T(3)) == T(2));
+    assert(obj == T(2));
+    assert((obj |= T(5)) == T(7));
+    assert(obj == T(7));
+    assert((obj &= T(0xF)) == T(7));
+    assert(obj == T(7));
+    assert((obj ^= T(0xF)) == T(8));
+    assert(obj == T(8));
+}
+
+template <template <typename> class A, class T>
+void test()
+{
+    do_test<A<T>, T>();
+    do_test<volatile A<T>, T>();
+    do_test<const A<T>, T>();
+    do_test<const volatile A<T>, T>();
+}
+
+int main(int, char**)
+{
+    test<std::atomic_ref, char>();
+    test<std::atomic_ref, signed char>();
+    test<std::atomic_ref, unsigned char>();
+    test<std::atomic_ref, short>();
+    test<std::atomic_ref, unsigned short>();
+    test<std::atomic_ref, int>();
+    test<std::atomic_ref, unsigned int>();
+    test<std::atomic_ref, long>();
+    test<std::atomic_ref, unsigned long>();
+    test<std::atomic_ref, long long>();
+    test<std::atomic_ref, unsigned long long>();
+#ifndef _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+    test<std::atomic_ref, char16_t>();
+    test<std::atomic_ref, char32_t>();
+#endif  // _LIBCUDACXX_HAS_NO_UNICODE_CHARS
+    test<std::atomic_ref, wchar_t>();
+
+    test<std::atomic_ref,    int8_t>();
+    test<std::atomic_ref,  uint8_t>();
+    test<std::atomic_ref,   int16_t>();
+    test<std::atomic_ref, uint16_t>();
+    test<std::atomic_ref,   int32_t>();
+    test<std::atomic_ref, uint32_t>();
+    test<std::atomic_ref,   int64_t>();
+    test<std::atomic_ref, uint64_t>();
+
+  return 0;
+}


### PR DESCRIPTION
# Changelog Summary

### Builds upon previous atomic refactor to create implementations of `cuda::atomic_ref` and `cuda::std::atomic_ref`

# Related Work

#179 - Refactor included back-end pathways for `atomic_ref` types.

# Details

This implementation conforms to the C++20 specification of [`atomic_ref`](http://eel.is/c++draft/atomics.ref.generic).

## Deviations

- `cuda::std::atomic_ref` is backported to C++11.
- `cuda::atomic_ref` has `fetch_min`/`fetch_max` overloads

## Motivation

`atomic_ref` provides a modern abstraction for visibility and ordering of reads and writes to memory according to the C++ memory model. This interface can be used to replace uses of CUDA specific `atomicOperation(_Scope)` functions in device code and provides interoperability with host code.

Previously:
```CUDA
__global__ atomic_kernel(int *out) {
  // Calculate some work per thread
  int bucket = threadIdx.x%16; 
  // Threads maybe have a different bucket, e.g. when computing a histogram
  atomicAdd(out+bucket, result); // Can't use `atomic<int>` on raw pointers :(
}
```

With `atomic_ref`:
```CUDA
#include <cuda/atomic>

__global__ atomic_kernel(int *out) {
  // Calculate some work per thread
 cuda::atomic_ref<int, cuda::thread_scope_block> bucket(out[threadIdx.x%16]);

  // Each thread may have a different bucket, e.g. when computing a histogram
 bucket += result;
}
```

## Design

Builds upon existing `atomic` pathways to create the `atomic_ref` front end. There were several changes required to properly cast into the correct lower level interface.

Tests for `atomic_ref` were replicated out of other `atomic` baseline tests, these provide coverage for both pointer and integral operations.

Host only libcxx tests were also added to provide coverage from a host standard library view and to ensure that the implementation is sound.

### Testing

#### Virtuals:

- AUSDVS: http://ausdvs.nvidia.com/Build_Results?virtualId=1000987553&which_page=current_build
- SCDVS: http://scdvs.nvidia.com/Build_Results?virtualId=1000075758&which_page=current_build

New tests have been added that exercise all interfaces of `atomic_ref`

<!--
## Impact

% Justify breaking changes, if any.
% Identify existing systems that expect to have performance changes.
% Identify any new systems that require benchmarks.
% Identify any security concerns, including new dependencies or CI
% components.

## Checklists

Verify that the following items are completed. Note that not all of these will be applicable to every Pull Request.

### Documentation

[ ] New public APIs have doxygen markup.
[ ] Any modified public APIs have updated doxygen markup.
[ ] Complex implementation details are clear and well commented.
[ ] New systems have examples that demonstrate their usage.
-->
