### PR TITLE
Fix buggy numerics of tanh(complex) at inf

### DIFF
--- a/.upstream-tests/test/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
@@ -58,18 +58,18 @@ __host__ __device__ void test_edges()
         }
         else if (cuda::std::isinf(testcases[i].real()) && cuda::std::isfinite(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
             assert(cuda::std::signbit(r.imag()) == cuda::std::signbit(sin(2*testcases[i].imag())));
         }
         else if (cuda::std::isinf(testcases[i].real()) && cuda::std::isinf(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
         }
         else if (cuda::std::isinf(testcases[i].real()) && cuda::std::isnan(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
         }
         else if (cuda::std::isnan(testcases[i].real()) && testcases[i].imag() == 0)

--- a/include/cuda/std/detail/libcxx/include/complex
+++ b/include/cuda/std/detail/libcxx/include/complex
@@ -1339,8 +1339,8 @@ tanh(const complex<_Tp>& __x)
     if (__libcpp_isinf_or_builtin(__x.real()))
     {
         if (!__libcpp_isfinite_or_builtin(__x.imag()))
-            return complex<_Tp>(_Tp(1), _Tp(0));
-        return complex<_Tp>(_Tp(1), copysign(_Tp(0), sin(_Tp(2) * __x.imag())));
+            return complex<_Tp>(copysign(_Tp(1), __x.real()), _Tp(0));
+        return complex<_Tp>(copysign(_Tp(1), __x.real()), copysign(_Tp(0), sin(_Tp(2) * __x.imag())));
     }
     if (__libcpp_isnan_or_builtin(__x.real()) && __x.imag() == 0)
         return __x;

--- a/libcxx/test/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex.transcendentals/tanh.pass.cpp
@@ -57,18 +57,18 @@ void test_edges()
         }
         else if (std::isinf(testcases[i].real()) && std::isfinite(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
             assert(std::signbit(r.imag()) == std::signbit(sin(2*testcases[i].imag())));
         }
         else if (std::isinf(testcases[i].real()) && std::isinf(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
         }
         else if (std::isinf(testcases[i].real()) && std::isnan(testcases[i].imag()))
         {
-            assert(r.real() == 1);
+            assert(r.real() == (testcases[i].real() > 0 ? 1 : -1));
             assert(r.imag() == 0);
         }
         else if (std::isnan(testcases[i].real()) && testcases[i].imag() == 0)


### PR DESCRIPTION
Because:
lim[x->inf, tanh(x+iy)] = 1
lim[x->-inf, tanh(x+iy)] = -1

Test:
```CUDA
#include <complex>
#include <cuda/std/complex>
#include <iostream>

constexpr float inf = std::numeric_limits<float>::infinity();

int main() {
    float values[] = {inf, 1, 0, -1, -inf};
    for (float r : values) {
        for (float i : values) {
            std::complex<float> s = {r, i};
            cuda::std::complex<float> c = {r, i};

            auto ts = std::tanh(s);
            auto tc = cuda::std::tanh(c);

            std::cout << "input: (" << r << ", " << i << ")" << std::endl;
            std::cout << "std: (" << ts.real() << ", " << ts.imag() << ")" << std::endl;
            std::cout << "cuda::std: (" << tc.real() << ", " << tc.imag() << ")" << std::endl;
            std::cout << std::endl;
        }
    }
}
```

Before:
```
input: (inf, inf)
std: (1, 0)
cuda::std: (1, 0)

input: (inf, 1)
std: (1, 0)
cuda::std: (1, 0)

input: (inf, 0)
std: (1, 0)
cuda::std: (1, 0)

input: (inf, -1)
std: (1, -0)
cuda::std: (1, -0)

input: (inf, -inf)
std: (1, -0)
cuda::std: (1, 0)

input: (1, inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (1, 1)
std: (1.08392, 0.271753)
cuda::std: (1.08392, 0.271753)

input: (1, 0)
std: (0.761594, 0)
cuda::std: (0.761594, 0)

input: (1, -1)
std: (1.08392, -0.271753)
cuda::std: (1.08392, -0.271753)

input: (1, -inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (0, inf)
std: (0, nan)
cuda::std: (-nan, -nan)

input: (0, 1)
std: (0, 1.55741)
cuda::std: (0, 1.55741)

input: (0, 0)
std: (0, 0)
cuda::std: (0, 0)

input: (0, -1)
std: (0, -1.55741)
cuda::std: (0, -1.55741)

input: (0, -inf)
std: (0, nan)
cuda::std: (-nan, -nan)

input: (-1, inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (-1, 1)
std: (-1.08392, 0.271753)
cuda::std: (-1.08392, 0.271753)

input: (-1, 0)
std: (-0.761594, 0)
cuda::std: (-0.761594, 0)

input: (-1, -1)
std: (-1.08392, -0.271753)
cuda::std: (-1.08392, -0.271753)

input: (-1, -inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (-inf, inf)
std: (-1, 0)
cuda::std: (1, 0)

input: (-inf, 1)
std: (-1, 0)
cuda::std: (1, 0)

input: (-inf, 0)
std: (-1, 0)
cuda::std: (1, 0)

input: (-inf, -1)
std: (-1, -0)
cuda::std: (1, -0)

input: (-inf, -inf)
std: (-1, -0)
cuda::std: (1, 0)
```

After:
```
input: (inf, inf)
std: (1, 0)
cuda::std: (1, 0)

input: (inf, 1)
std: (1, 0)
cuda::std: (1, 0)

input: (inf, 0)
std: (1, 0)
cuda::std: (1, 0)

input: (inf, -1)
std: (1, -0)
cuda::std: (1, -0)

input: (inf, -inf)
std: (1, -0)
cuda::std: (1, 0)

input: (1, inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (1, 1)
std: (1.08392, 0.271753)
cuda::std: (1.08392, 0.271753)

input: (1, 0)
std: (0.761594, 0)
cuda::std: (0.761594, 0)

input: (1, -1)
std: (1.08392, -0.271753)
cuda::std: (1.08392, -0.271753)

input: (1, -inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (0, inf)
std: (0, nan)
cuda::std: (-nan, -nan)

input: (0, 1)
std: (0, 1.55741)
cuda::std: (0, 1.55741)

input: (0, 0)
std: (0, 0)
cuda::std: (0, 0)

input: (0, -1)
std: (0, -1.55741)
cuda::std: (0, -1.55741)

input: (0, -inf)
std: (0, nan)
cuda::std: (-nan, -nan)

input: (-1, inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (-1, 1)
std: (-1.08392, 0.271753)
cuda::std: (-1.08392, 0.271753)

input: (-1, 0)
std: (-0.761594, 0)
cuda::std: (-0.761594, 0)

input: (-1, -1)
std: (-1.08392, -0.271753)
cuda::std: (-1.08392, -0.271753)

input: (-1, -inf)
std: (nan, nan)
cuda::std: (-nan, -nan)

input: (-inf, inf)
std: (-1, 0)
cuda::std: (-1, 0)

input: (-inf, 1)
std: (-1, 0)
cuda::std: (-1, 0)

input: (-inf, 0)
std: (-1, 0)
cuda::std: (-1, 0)

input: (-inf, -1)
std: (-1, -0)
cuda::std: (-1, -0)

input: (-inf, -inf)
std: (-1, -0)
cuda::std: (-1, 0)
```

Thanks a lot cc @mruberry @ngimel for discussion.