### PR TITLE
Fix `<nv/target>` for MSVC

### DIFF
--- a/include/nv/detail/__preprocessor
+++ b/include/nv/detail/__preprocessor
@@ -18,13 +18,13 @@
 //  _NV_FIRST_ARG
 //  _NV_REMOVE_PAREN
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(_NV_TARGET_CPP11)
 #  define _NV_EVAL1(...) __VA_ARGS__
 #  define _NV_EVAL(...) _NV_EVAL1(__VA_ARGS__)
 #else
 #  define _NV_EVAL1(x) x
 #  define _NV_EVAL(x) _NV_EVAL1(x)
-#endif // defined(__cplusplus) && __cplusplus >= 201103L
+#endif // C++11
 
 #define _NV_CONCAT_EVAL1(l, r) _NV_EVAL(l ## r)
 #define _NV_CONCAT_EVAL(l, r) _NV_CONCAT_EVAL1(l, r)
@@ -39,7 +39,7 @@
 #define _NV_IF1(cond, t, f) _NV_IF_EVAL(cond, t, f)
 #define _NV_IF(cond, t, f) _NV_IF1(_NV_EVAL(cond), _NV_EVAL(t), _NV_EVAL(f))
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(_NV_TARGET_CPP11)
 
 // The below mechanisms were derived from: https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/
 
@@ -111,4 +111,4 @@
 #define _NV_DISPATCH_N_IMPL(name, ...) _NV_DISPATCH_N_IMPL0(_NV_NUM_ARGS(__VA_ARGS__), name, __VA_ARGS__)
 #define _NV_DISPATCH_N_ARY(name, ...) _NV_DISPATCH_N_IMPL(name, __VA_ARGS__)
 
-#endif // defined(__cplusplus) && __cplusplus >= 201103L
+#endif // C++11

--- a/include/nv/detail/__target_macros
+++ b/include/nv/detail/__target_macros
@@ -393,7 +393,7 @@
 
 #    define _NV_TARGET_EMPTY_PARAM ;
 
-#  if defined(__cplusplus) && __cplusplus >= 201103L
+#  if defined(_NV_TARGET_CPP11)
 
 #    define _NV_BLOCK_EXPAND(...) { _NV_REMOVE_PAREN(__VA_ARGS__) }
 #    define _NV_TARGET_IF(cond, t, ...) _NV_IF( _NV_ARCH_COND_CAT(cond), t, __VA_ARGS__)
@@ -409,7 +409,7 @@
 
 #endif // _NV_COMPILER_NVCC
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(_NV_TARGET_CPP11)
 
 #  define _NV_TARGET_DISPATCH_HANDLE0()
 #  define _NV_TARGET_DISPATCH_HANDLE2(q, fn)        _NV_TARGET_IF(q, fn)

--- a/include/nv/target
+++ b/include/nv/target
@@ -11,7 +11,8 @@
 // CUDA C++ development with NVC++, NVCC, and supported host compilers.
 // These interfaces are not guaranteed to be stable.
 
-#pragma once
+#ifndef __NV_TARGET_H
+#define __NV_TARGET_H
 
 #if defined(__NVCC__) || defined(__CUDACC_RTC__)
 #  define _NV_COMPILER_NVCC
@@ -31,7 +32,12 @@
 #  define _NV_BITSET_ATTRIBUTE
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if (defined(__cplusplus) && __cplusplus >= 201103L) || \
+    (defined(_MSC_VER) && _MSVC_LANG >= 201103L)
+#  define _NV_TARGET_CPP11
+#endif
+
+#if defined(_NV_TARGET_CPP11)
 
 namespace nv {
   namespace target {
@@ -184,3 +190,4 @@ namespace nv {
 
 #include "detail/__target_macros"
 
+#endif // __NV_TARGET_H


### PR DESCRIPTION
Currently libcudacxx will always choose the pre-c++11 macro backend for `<nv/target>`. This patch fixes that by introducing checks for `_MSVC_LANG` an 'almost' always correct representation of the current C++ dialect. 