### PR TITLE
Fix host only compilation of <cuda/std/cmath>

### DIFF
--- a/include/cuda/std/cmath
+++ b/include/cuda/std/cmath
@@ -16,11 +16,12 @@
 
 #include "detail/__pragma_push"
 
+#ifndef _LIBCUDACXX_COMPILER_NVRTC
 #include <math.h>
+#endif
 #include "detail/libcxx/include/cmath"
 
 #include "detail/__pragma_pop"
 
 #endif //_CUDA_CMATH
-
 

--- a/include/cuda/std/cmath
+++ b/include/cuda/std/cmath
@@ -16,6 +16,7 @@
 
 #include "detail/__pragma_push"
 
+#include <math.h>
 #include "detail/libcxx/include/cmath"
 
 #include "detail/__pragma_pop"

--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -792,6 +792,11 @@ typedef __char32_t char32_t;
 #define _LIBCUDACXX_HAS_NO_ASAN
 #endif
 
+// GCC implemented P0030R1 in 7.0, maybe only available under experimental?
+#if _GNUC_VER < 700
+#define _LIBCUDACXX_NO_HOST_CPP17_HYPOT
+#endif
+
 #if _GNUC_VER < 600 && defined(_LIBCUDACXX_COMPILER_NVCC)
 #define _LIBCUDACXX_MISSING_GCC_MATH_INTRINSICS
 #endif

--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -792,11 +792,6 @@ typedef __char32_t char32_t;
 #define _LIBCUDACXX_HAS_NO_ASAN
 #endif
 
-// GCC implemented P0030R1 in 7.0, maybe only available under experimental?
-#if _GNUC_VER < 700
-#define _LIBCUDACXX_NO_HOST_CPP17_HYPOT
-#endif
-
 #if _GNUC_VER < 600 && defined(_LIBCUDACXX_COMPILER_NVCC)
 #define _LIBCUDACXX_MISSING_GCC_MATH_INTRINSICS
 #endif

--- a/include/cuda/std/detail/libcxx/include/cmath
+++ b/include/cuda/std/detail/libcxx/include/cmath
@@ -565,7 +565,7 @@ using ::tgammal;
 using ::truncl;
 #endif
 
-#if _LIBCUDACXX_STD_VER > 14 && (defined(_LIBCUDACXX_NO_HOST_CPP17_HYPOT) || !defined(_LIBCUDACXX_COMPILER_NVCC))
+#if _LIBCUDACXX_STD_VER > 14 && (defined(_LIBCUDACXX_NO_HOST_CPP17_HYPOT))
 inline _LIBCUDACXX_INLINE_VISIBILITY float       hypot(       float x,       float y,       float z ) { return sqrt(x*x + y*y + z*z); }
 inline _LIBCUDACXX_INLINE_VISIBILITY double      hypot(      double x,      double y,      double z ) { return sqrt(x*x + y*y + z*z); }
 #ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE

--- a/include/cuda/std/detail/libcxx/include/cmath
+++ b/include/cuda/std/detail/libcxx/include/cmath
@@ -565,7 +565,7 @@ using ::tgammal;
 using ::truncl;
 #endif
 
-#if _LIBCUDACXX_STD_VER > 14 && (defined(_LIBCUDACXX_NO_HOST_CPP17_HYPOT))
+#if _LIBCUDACXX_STD_VER > 14 && !defined(__cuda_std__)
 inline _LIBCUDACXX_INLINE_VISIBILITY float       hypot(       float x,       float y,       float z ) { return sqrt(x*x + y*y + z*z); }
 inline _LIBCUDACXX_INLINE_VISIBILITY double      hypot(      double x,      double y,      double z ) { return sqrt(x*x + y*y + z*z); }
 #ifdef _LIBCUDACXX_HAS_COMPLEX_LONG_DOUBLE

--- a/include/cuda/std/detail/libcxx/include/cmath
+++ b/include/cuda/std/detail/libcxx/include/cmath
@@ -596,7 +596,13 @@ _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR typename enable_if<is_floating_point<_A1>::value, bool>::type
 __libcpp_isnan_or_builtin(_A1 __lcpp_x) _NOEXCEPT
 {
-    return isnan(static_cast<double>(__lcpp_x));
+#if defined(__CUDA_ARCH__)
+    return __isnan(__lcpp_x);
+#elif __has_builtin(__builtin_isnan)
+    return __builtin_isnan(__lcpp_x);
+#else
+    return isnan(__lcpp_x);
+#endif
 }
 
 template <class _A1>
@@ -612,7 +618,13 @@ _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR typename enable_if<is_floating_point<_A1>::value, bool>::type
 __libcpp_isinf_or_builtin(_A1 __lcpp_x) _NOEXCEPT
 {
-    return isinf(static_cast<double>(__lcpp_x));
+#if defined(__CUDA_ARCH__)
+    return __isinf(__lcpp_x);
+#elif __has_builtin(__builtin_isnan)
+    return __builtin_isinf(__lcpp_x);
+#else
+    return isinf(__lcpp_x);
+#endif
 }
 
 template <class _A1>
@@ -628,7 +640,11 @@ _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR typename enable_if<is_floating_point<_A1>::value, bool>::type
 __libcpp_isfinite_or_builtin(_A1 __lcpp_x) _NOEXCEPT
 {
-    return isfinite(static_cast<double>(__lcpp_x));
+#if !defined(__CUDA_ARCH__) && __has_builtin(__builtin_isnan)
+    return __builtin_isfinite(__lcpp_x);
+#else
+    return isfinite(__lcpp_x);
+#endif
 }
 
 template <class _A1>


### PR DESCRIPTION
This patch set fixes compilation on clang and gcc. Currently there are missing/extra definitions caused by nvcc including math.h by default.

VDVS: https://builds4u.nvidia.com/dvs/#/change/3067999458696529.1?eventType=Virtual&dvs_showStaging=on