### PR TITLE
Fix several truncations and warnings in numerics

### DIFF
--- a/.upstream-tests/test/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
+++ b/.upstream-tests/test/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
@@ -14,6 +14,11 @@
 #include <cuda/std/cfloat>
 #include <cuda/std/cassert>
 
+// MSVC has issues with producing INF with divisions by zero.
+#if defined(_MSC_VER)
+#  include <cmath>
+#endif
+
 #include "test_macros.h"
 
 template <class T>
@@ -56,9 +61,16 @@ int main(int, char**)
 #if !defined(_MSC_VER)
     test<float>(1.f/0.f);
     test<double>(1./0.);
-#ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
+#  ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
     test<long double>(1. / 0.);
-#endif
+#  endif
+// MSVC has issues with producing INF with divisions by zero.
+#else
+    test<float>(INFINITY);
+    test<double>(INFINITY);
+#  ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
+    test<long double>(INFINITY);
+#  endif
 #endif
 
     return 0;

--- a/.upstream-tests/test/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
+++ b/.upstream-tests/test/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
@@ -53,10 +53,12 @@ int main(int, char**)
     test<__int128_t>(0);
     test<__uint128_t>(0);
 #endif
+#if !defined(_MSC_VER)
     test<float>(1.f/0.f);
     test<double>(1./0.);
 #ifndef _LIBCUDACXX_HAS_NO_LONG_DOUBLE
     test<long double>(1. / 0.);
+#endif
 #endif
 
     return 0;

--- a/.upstream-tests/test/std/numerics/bit/bitops.count/popcount.pass.cpp
+++ b/.upstream-tests/test/std/numerics/bit/bitops.count/popcount.pass.cpp
@@ -23,6 +23,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+// MSVC 14.12 erroneously notices an integer overflow
+# pragma warning( disable: 4307 )
+#endif
+
 class A{};
 enum       E1 : unsigned char { rEd };
 enum class E2 : unsigned char { red };

--- a/.upstream-tests/test/std/numerics/complex.number/cases.h
+++ b/.upstream-tests/test/std/numerics/complex.number/cases.h
@@ -21,7 +21,7 @@ using testcases_t = cuda::std::complex<double>[152];
 struct _testcases {
     testcases_t _cases;
 
-    static constexpr size_t count = sizeof(_cases) / sizeof(_cases[0]);
+    static constexpr size_t count = sizeof(testcases_t) / sizeof(cuda::std::complex<double>);
 
     __host__ __device__  const cuda::std::complex<double>* begin() const {
         return  &_cases[0];

--- a/include/cuda/std/detail/libcxx/include/limits
+++ b/include/cuda/std/detail/libcxx/include/limits
@@ -190,7 +190,7 @@ protected:
 template <class _Tp, int __digits, bool _IsSigned>
 struct __libcpp_compute_min
 {
-    static _LIBCUDACXX_CONSTEXPR const _Tp value = _Tp(_Tp(1) << __digits);
+    static _LIBCUDACXX_CONSTEXPR const _Tp value = static_cast<_Tp>(_Tp(1) << __digits);
 };
 
 template <class _Tp, int __digits>


### PR DESCRIPTION
This fixes some longstanding MSVC issues. No functional impact, but resolves a few warnings making tests build clean.

https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/3556730