### PR TITLE
Fix warnings in an array test and move escapes in algorithm.

### DIFF
--- a/.upstream-tests/test/std/containers/sequences/array/size_and_alignment.pass.cpp
+++ b/.upstream-tests/test/std/containers/sequences/array/size_and_alignment.pass.cpp
@@ -20,6 +20,10 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4324)
+#endif
+
 template <typename T>
 __host__ __device__
 constexpr bool unused(T &&) {return true;}

--- a/include/cuda/std/detail/libcxx/include/algorithm
+++ b/include/cuda/std/detail/libcxx/include/algorithm
@@ -2512,6 +2512,7 @@ rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterato
     return _CUDA_VSTD::copy(__first, __middle, _CUDA_VSTD::copy(__middle, __last, __result));
 }
 
+#endif // __cuda_std__
 // min_element
 
 template <class _ForwardIterator, class _Compare>
@@ -2814,6 +2815,8 @@ minmax(::std::initializer_list<_Tp> __t)
 }
 
 #endif  // _LIBCUDACXX_CXX03_LANG
+
+#ifndef __cuda_std__
 
 // random_shuffle
 


### PR DESCRIPTION
Fixes a warning in array tests. Adds a missing `__cuda_std__` escape.

https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/3556730