### PR TITLE
Fix deprecated implicit copy constructor warnings in __annotated_ptr

### DIFF
--- a/include/cuda/std/detail/__annotated_ptr
+++ b/include/cuda/std/detail/__annotated_ptr
@@ -124,6 +124,7 @@ namespace __detail_ap {
 
       constexpr __annotated_ptr_base() noexcept = default;
       constexpr __annotated_ptr_base(__annotated_ptr_base const&) = default;
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __annotated_ptr_base& operator=(const __annotated_ptr_base&) = default;
       __device__ void* __apply_prop(void* __p) const {
         return __associate(__p, access_property::shared{});
       }
@@ -136,6 +137,7 @@ namespace __detail_ap {
 
       constexpr __annotated_ptr_base() noexcept = default;
       constexpr __annotated_ptr_base(__annotated_ptr_base const&) = default;
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __annotated_ptr_base& operator=(const __annotated_ptr_base&) = default;
       __device__ void* __apply_prop(void* __p) const {
         return __associate(__p, access_property::global{});
       }
@@ -148,6 +150,7 @@ namespace __detail_ap {
 
       constexpr __annotated_ptr_base() noexcept = default;
       constexpr __annotated_ptr_base(__annotated_ptr_base const&) = default;
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __annotated_ptr_base& operator=(const __annotated_ptr_base&) = default;
       __device__ void* __apply_prop(void* __p) const {
         return __associate(__p, access_property::normal{});
       }
@@ -160,6 +163,7 @@ namespace __detail_ap {
 
       constexpr __annotated_ptr_base() noexcept = default;
       constexpr __annotated_ptr_base(__annotated_ptr_base const&) = default;
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __annotated_ptr_base& operator=(const __annotated_ptr_base&) = default;
       __device__ void* __apply_prop(void* __p) const {
         return __associate(__p, access_property::persisting{});
       }
@@ -172,6 +176,7 @@ namespace __detail_ap {
 
       constexpr __annotated_ptr_base() noexcept = default;
       constexpr __annotated_ptr_base(__annotated_ptr_base const&) = default;
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __annotated_ptr_base& operator=(const __annotated_ptr_base&) = default;
       __device__ void* __apply_prop(void* __p) const {
         return __associate(__p, access_property::streaming{});
       }
@@ -185,6 +190,7 @@ namespace __detail_ap {
       __host__ __device__ constexpr __annotated_ptr_base() noexcept : __prop(access_property()) {}
       __host__ __device__ constexpr __annotated_ptr_base(std::uint64_t __property) noexcept : __prop(__property) {}
       constexpr __annotated_ptr_base(__annotated_ptr_base const&) = default;
+      _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 __annotated_ptr_base& operator=(const __annotated_ptr_base&) = default;
       __device__ void* __apply_prop(void* __p) const {
         return __associate(__p, __prop);
       }


### PR DESCRIPTION
```
include/cuda/std/detail/__annotated_ptr:126:11: error: definition of implicit copy assignment operator for '__annotated_ptr_base<cuda::access_property::shared>' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
constexpr __annotated_ptr_base(const __detail_ap::__annotated_ptr_base< access_property::shared>  &) = default;
```

Fixes this warning in Clang-13.