### PR TITLE
Increase contrast of search input text in docs.

### DIFF
--- a/docs/_sass/color_schemes/nvidia.scss
+++ b/docs/_sass/color_schemes/nvidia.scss
@@ -121,3 +121,4 @@ pre.highlight code
 .highlight span.gd { color: #ff0000 } /* Generic.Deleted */
 .highlight span.gi { color: #00ff00 } /* Generic.Inserted */
 
+.search-input { color: $body-text-color; }


### PR DESCRIPTION
This PR increases the contrast of the documentation's search bar text so that the input text is legible.

If this PR is approved/merged, I will make a similar PR to improve Thrust's documentation. If anyone is aware of other instances of this issue, let me know and I can make corresponding updates to other repositories.

Before:
![image](https://user-images.githubusercontent.com/3943761/159189157-64f1985c-1537-4fc4-a241-18285f2f5b65.png)

After:
![image](https://user-images.githubusercontent.com/3943761/159189171-dbe56095-056a-403f-a7ba-902e20844901.png)
