### PR TITLE
Forcefully disable warnings in GCC for <nv/target>

### DIFF
--- a/include/nv/detail/__preprocessor
+++ b/include/nv/detail/__preprocessor
@@ -7,6 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC system_header
+#endif
 
 // For all compilers and dialects this header defines:
 //  _NV_EVAL

--- a/include/nv/detail/__preprocessor
+++ b/include/nv/detail/__preprocessor
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__)
 #pragma GCC system_header
 #endif
 

--- a/include/nv/detail/__target_macros
+++ b/include/nv/detail/__target_macros
@@ -12,6 +12,10 @@
 
 #include "__preprocessor"
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC system_header
+#endif
+
 #  define _NV_TARGET_ARCH_TO_SELECTOR_350 nv::target::sm_35
 #  define _NV_TARGET_ARCH_TO_SELECTOR_370 nv::target::sm_37
 #  define _NV_TARGET_ARCH_TO_SELECTOR_500 nv::target::sm_50

--- a/include/nv/detail/__target_macros
+++ b/include/nv/detail/__target_macros
@@ -12,7 +12,7 @@
 
 #include "__preprocessor"
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__)
 #pragma GCC system_header
 #endif
 


### PR DESCRIPTION
Currently GCC 6 and down produces this warning when compile with `-Wpedantic`

```
<source>:594:1: warning: ISO C++11 requires at least one argument for the "..." in a variadic macro
     )
```

While it's possible to ignore `-Wpedantic`, I believe it would be more reliable to silence warnings by marking the details of <nv/target> as `system_header`s.