### PR TITLE
Fix MSVC test failures.

### DIFF
--- a/.upstream-tests/test/heterogeneous/tuple.pass.cpp
+++ b/.upstream-tests/test/heterogeneous/tuple.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: nvrtc
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // uncomment for a really verbose output detailing what test steps are being launched
 // #define DEBUG_TESTERS

--- a/.upstream-tests/test/heterogeneous/tuple.pass.cpp
+++ b/.upstream-tests/test/heterogeneous/tuple.pass.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: nvrtc
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // uncomment for a really verbose output detailing what test steps are being launched
 // #define DEBUG_TESTERS

--- a/.upstream-tests/test/std/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -14,16 +14,16 @@
 // template<Integral T>   complex<double>      conj(T);
 //                        complex<float>       conj(float);
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/type_traits>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 #include "../cases.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T>
 __host__ __device__ void

--- a/.upstream-tests/test/std/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -20,16 +20,16 @@
 //   complex<promote<T, U>::type>
 //   pow(const complex<T>& x, const complex<U>& y);
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/type_traits>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 #include "../cases.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T>
 __host__ __device__ double

--- a/.upstream-tests/test/std/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -14,16 +14,16 @@
 // template<Integral T> complex<double>      proj(T);
 //                      complex<float>       proj(float);
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/type_traits>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 #include "../cases.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T>
 __host__ __device__ void

--- a/.upstream-tests/test/std/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -12,16 +12,16 @@
 //   T
 //   real(const T& x);
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/type_traits>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
 #include "../cases.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T, int x>
 __host__ __device__ void

--- a/.upstream-tests/test/std/numerics/complex.number/complex.member.ops/assignment_complex.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/complex.member.ops/assignment_complex.pass.cpp
@@ -11,14 +11,14 @@
 // complex& operator=(const complex&);
 // template<class X> complex& operator= (const complex<X>&);
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T, class X>
 __host__ __device__ void

--- a/.upstream-tests/test/std/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
@@ -10,14 +10,14 @@
 
 // complex& operator/=(const complex& rhs);
 
+#if defined(_MSC_VER)
+#  pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T>
 __host__ __device__ void

--- a/.upstream-tests/test/std/numerics/complex.number/complex.member.ops/times_equal_complex.pass.cpp
+++ b/.upstream-tests/test/std/numerics/complex.number/complex.member.ops/times_equal_complex.pass.cpp
@@ -10,14 +10,14 @@
 
 // complex& operator*=(const complex& rhs);
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
+#endif
+
 #include <cuda/std/complex>
 #include <cuda/std/cassert>
 
 #include "test_macros.h"
-
-#if defined(_MSC_VER)
-#pragma warning(disable: 4244) // conversion from 'const double' to 'int', possible loss of data
-#endif
 
 template <class T>
 __host__ __device__ void

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
@@ -19,6 +19,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
@@ -19,6 +19,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 template <typename D, typename Ds>
 __host__ __device__
 constexpr bool testConstexpr()

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
@@ -23,6 +23,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 template <typename D, typename Ds>
 __host__ __device__
 constexpr bool testConstexpr()

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
@@ -23,6 +23,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
@@ -25,6 +25,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 template <typename M, typename Ms>
 __host__ __device__
 constexpr bool testConstexpr()

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
@@ -25,6 +25,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.local_days.pass.cpp
@@ -29,6 +29,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 int main(int, char**)
 {
     using year           = cuda::std::chrono::year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.local_days.pass.cpp
@@ -29,6 +29,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp
@@ -12,7 +12,7 @@
 
 //  constexpr year_month_day(const sys_days& dp) noexcept;
 //
-//  Effects:  Constructs an object of type year_month_day that corresponds 
+//  Effects:  Constructs an object of type year_month_day that corresponds
 //                to the date represented by dp.
 //
 //  Remarks: For any value ymd of type year_month_day for which ymd.ok() is true,
@@ -27,6 +27,11 @@
 #include <cassert>
 
 #include "test_macros.h"
+
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
 
 int main(int, char**)
 {

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp
@@ -28,6 +28,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.local_days.pass.cpp
@@ -35,6 +35,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.local_days.pass.cpp
@@ -35,6 +35,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 __host__ __device__
 void RunTheExample()
 {
@@ -42,7 +47,7 @@ void RunTheExample()
 
     static_assert(year_month_day{local_days{year{2017}/January/0}}  == year{2016}/December/31,"");
     static_assert(year_month_day{local_days{year{2017}/January/31}} == year{2017}/January/31,"");
-    static_assert(year_month_day{local_days{year{2017}/January/32}} == year{2017}/February/1,"");  
+    static_assert(year_month_day{local_days{year{2017}/January/32}} == year{2017}/February/1,"");
 }
 
 int main(int, char**)

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp
@@ -35,6 +35,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 __host__ __device__
 void RunTheExample()
 {
@@ -42,7 +47,7 @@ void RunTheExample()
 
     static_assert(year_month_day{sys_days{year{2017}/January/0}}  == year{2016}/December/31,"");
     static_assert(year_month_day{sys_days{year{2017}/January/31}} == year{2017}/January/31,"");
-    static_assert(year_month_day{sys_days{year{2017}/January/32}} == year{2017}/February/1,"");  
+    static_assert(year_month_day{sys_days{year{2017}/January/32}} == year{2017}/February/1,"");
 }
 
 int main(int, char**)

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp
@@ -35,6 +35,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.local_days.pass.cpp
@@ -29,6 +29,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 int main(int, char**)
 {
     using year               = cuda::std::chrono::year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.local_days.pass.cpp
@@ -29,6 +29,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp
@@ -28,6 +28,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 int main(int, char**)
 {
     using year               = cuda::std::chrono::year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp
@@ -28,6 +28,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp
@@ -25,6 +25,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 int main(int, char**)
 {
     using year               = cuda::std::chrono::year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp
@@ -25,6 +25,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp
@@ -25,6 +25,11 @@
 
 #include "test_macros.h"
 
+#if defined(_MSC_VER)
+# pragma warning( disable: 4307 )
+# pragma warning( disable: 4308 )
+#endif
+
 int main(int, char**)
 {
     using year               = cuda::std::chrono::year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp
@@ -25,6 +25,8 @@
 
 #include "test_macros.h"
 
+// MSVC warns about unsigned/signed comparisons and addition/subtraction
+// Silence these warnings, but not the ones within the header itself.
 #if defined(_MSC_VER)
 # pragma warning( disable: 4307 )
 # pragma warning( disable: 4308 )

--- a/.upstream-tests/test/std/utilities/tuple/tuple.general/ignore.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.general/ignore.pass.cpp
@@ -12,7 +12,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.general/ignore.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.general/ignore.pass.cpp
@@ -10,7 +10,9 @@
 
 // constexpr unspecified ignore;
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.general/tuple.smartptr.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.general/tuple.smartptr.pass.cpp
@@ -9,7 +9,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 //  Tuples of smart pointers; based on bug #18350
 //  auto_ptr doesn't have a copy constructor that takes a const &, but tuple does.

--- a/.upstream-tests/test/std/utilities/tuple/tuple.general/tuple.smartptr.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.general/tuple.smartptr.pass.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 //
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 //  Tuples of smart pointers; based on bug #18350
 //  auto_ptr doesn't have a copy constructor that takes a const &, but tuple does.

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/TupleFunction.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/TupleFunction.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // This is for bugs 18853 and 19118
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/TupleFunction.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/TupleFunction.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // This is for bugs 18853 and 19118
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // UNSUPPORTED: nvrtc
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 // <cuda/std/tuple>
 
 // template <class F, class T> constexpr decltype(auto) apply(F &&, T &&)

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply.pass.cpp
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14 
+// UNSUPPORTED: c++98, c++03, c++11, c++14
 // UNSUPPORTED: nvrtc
-
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 // <cuda/std/tuple>
 
 // template <class F, class T> constexpr decltype(auto) apply(F &&, T &&)

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_extended_types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_extended_types.pass.cpp
@@ -10,7 +10,7 @@
 
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_extended_types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_extended_types.pass.cpp
@@ -8,7 +8,9 @@
 
 
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14 
+// UNSUPPORTED: c++98, c++03, c++11, c++14
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // UNSUPPORTED: nvrtc
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp
@@ -8,6 +8,8 @@
 
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // UNSUPPORTED: nvrtc
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // UNSUPPORTED: nvrtc
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.apply/make_from_tuple.pass.cpp
@@ -8,6 +8,8 @@
 
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // UNSUPPORTED: nvrtc
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/const_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/const_pair.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/const_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/const_pair.pass.cpp
@@ -13,7 +13,9 @@
 // template <class U1, class U2>
 //   tuple& operator=(const pair<U1, U2>& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_copy.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_copy.pass.cpp
@@ -14,6 +14,8 @@
 //   tuple& operator=(const tuple<UTypes...>& u);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_copy.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-
 // <cuda/std/tuple>
 
 // template <class... Types> class tuple;
@@ -15,7 +13,7 @@
 // template <class... UTypes>
 //   tuple& operator=(const tuple<UTypes...>& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>
@@ -76,6 +74,7 @@ int main(int, char**)
         assert(cuda::std::get<1>(t1) == int('a'));
         assert(cuda::std::get<2>(t1).id_ == 2);
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         // Test that tuple evaluates correctly applies an lvalue reference
         // before evaluating is_assignable (ie 'is_assignable<int&, int&>')
@@ -88,6 +87,6 @@ int main(int, char**)
         assert(cuda::std::get<0>(t) == 43);
         assert(&cuda::std::get<0>(t) == &x);
     }
-
+#endif
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
@@ -16,6 +16,8 @@
 //   tuple& operator=(tuple<UTypes...>&& u);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
@@ -15,7 +15,7 @@
 // template <class... UTypes>
 //   tuple& operator=(tuple<UTypes...>&& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -98,6 +98,7 @@ int main(int, char**)
         assert(cuda::std::get<1>(t1) == int('a'));
         assert(cuda::std::get<2>(t1)->id_ == 3);
     }*/
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         // Test that tuple evaluates correctly applies an lvalue reference
         // before evaluating is_assignable (ie 'is_assignable<int&, int&&>')
@@ -110,6 +111,6 @@ int main(int, char**)
         assert(cuda::std::get<0>(t) == 43);
         assert(&cuda::std::get<0>(t) == &x);
     }
-
+#endif
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/convert_move.pass.cpp
@@ -17,7 +17,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/copy.pass.cpp
@@ -14,7 +14,7 @@
 
 // tuple& operator=(const tuple& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>
@@ -75,6 +75,7 @@ int main(int, char**)
         assert(cuda::std::get<2>(t) == "some text");
     }
     */
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         // test reference assignment.
         using T = cuda::std::tuple<int&, int&&>;
@@ -90,6 +91,7 @@ int main(int, char**)
         assert(cuda::std::get<1>(t) == y2);
         assert(&cuda::std::get<1>(t) == &y);
     }
+#endif
     // cuda::std::unique_ptr not supported
     /*
     {

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/copy.pass.cpp
@@ -15,6 +15,8 @@
 // tuple& operator=(const tuple& u);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/copy.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
@@ -14,7 +14,7 @@
 
 // tuple& operator=(tuple&& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -65,6 +65,7 @@ int main(int, char**)
         t = cuda::std::move(t0);
         unused(t);
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         typedef cuda::std::tuple<MoveOnly> T;
         T t0(MoveOnly(0));
@@ -104,6 +105,7 @@ int main(int, char**)
         assert(cuda::std::get<1>(t) == y2);
         assert(&cuda::std::get<1>(t) == &y);
     }
+#endif
     // cuda::std::unique_ptr not supported
     /*
     {

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move.pass.cpp
@@ -15,6 +15,8 @@
 // tuple& operator=(tuple&& u);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move_pair.pass.cpp
@@ -13,7 +13,9 @@
 // template <class U1, class U2>
 //   tuple& operator=(pair<U1, U2>&& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.assign/move_pair.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR20855_tuple_ref_binding_diagnostics.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR20855_tuple_ref_binding_diagnostics.pass.cpp
@@ -7,9 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR20855_tuple_ref_binding_diagnostics.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR20855_tuple_ref_binding_diagnostics.pass.cpp
@@ -9,7 +9,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
@@ -8,7 +8,7 @@
 
 
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 // <cuda/std/tuple>
 
@@ -96,9 +96,11 @@ int main(int, char**)
     // cuda::std::allocator not supported
     // cuda::std::allocator<int> A;
     { // rvalue reference
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         T t1(42);
         cuda::std::tuple< T&& > t2(cuda::std::move(t1));
         assert(&cuda::std::get<0>(t2) == &t1);
+#endif
     }
     { // const lvalue reference
         T t1(42);
@@ -116,10 +118,12 @@ int main(int, char**)
         assert(&cuda::std::get<0>(t2) == &t1);
     }
     { // const rvalue reference
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         T t1(42);
 
         cuda::std::tuple< T const && > t2(cuda::std::move(t1));
         assert(&cuda::std::get<0>(t2) == &t1);
+#endif
     }
     // cuda::std::allocator not supported
     /*
@@ -154,16 +158,20 @@ int main(int, char**)
     // the 'tuple(UTypes...)' ctor should be chosen and 'UDT' constructed from
     // 'tuple<T>'.
     {
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         using VT = ConstructibleFromTupleAndInt;
         cuda::std::tuple<int> t1(42);
         cuda::std::tuple<VT> t2(t1);
         assert(cuda::std::get<0>(t2).state == VT::FromTuple);
+#endif
     }
     {
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         using VT = ConvertibleFromTupleAndInt;
         cuda::std::tuple<int> t1(42);
         cuda::std::tuple<VT> t2 = {t1};
         assert(cuda::std::get<0>(t2).state == VT::FromTuple);
+#endif
     }
     // Test constructing a 1-tuple of the form tuple<UDT> from another 1-tuple
     // 'tuple<T>' where UDT cannot be constructed from 'tuple<T>' but can

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
@@ -10,7 +10,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
@@ -9,6 +9,8 @@
 
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR23256_constrain_UTypes_ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/PR23256_constrain_UTypes_ctor.pass.cpp
@@ -8,7 +8,8 @@
 
 
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// XFAIL: msvc
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/UTypes.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/UTypes.pass.cpp
@@ -14,6 +14,7 @@
 //   explicit tuple(UTypes&&... u);
 
 // XFAIL: gcc-4.8, gcc-4.9
+// XFAIL: msvc-19.12, msvc-19.13
 
 // UNSUPPORTED: c++98, c++03
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/UTypes.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/UTypes.pass.cpp
@@ -16,7 +16,7 @@
 // XFAIL: gcc-4.8, gcc-4.9
 // XFAIL: msvc-19.12, msvc-19.13
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // UNSUPPORTED: c++98, c++03
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/UTypes.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/UTypes.pass.cpp
@@ -15,6 +15,8 @@
 
 // XFAIL: gcc-4.8, gcc-4.9
 // XFAIL: msvc-19.12, msvc-19.13
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // UNSUPPORTED: c++98, c++03
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc, class... UTypes>
 //   tuple(allocator_arg_t, const Alloc& a, UTypes&&...);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_UTypes.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_Types.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc>
 //   tuple(allocator_arg_t, const Alloc& a, const Types&...);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_pair.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_const_pair.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc, class U1, class U2>
 //   tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_copy.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_copy.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc, class... UTypes>
 //   tuple(allocator_arg_t, const Alloc& a, const tuple<UTypes...>&);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_move.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_convert_move.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc, class... UTypes>
 //   tuple(allocator_arg_t, const Alloc& a, tuple<UTypes...>&&);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_copy.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc>
 //   tuple(allocator_arg_t, const Alloc& a, const tuple&);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_copy.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move.pass.cpp
@@ -14,6 +14,8 @@
 //   tuple(allocator_arg_t, const Alloc& a, tuple&&);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move.pass.cpp
@@ -13,7 +13,7 @@
 // template <class Alloc>
 //   tuple(allocator_arg_t, const Alloc& a, tuple&&);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>
@@ -32,10 +32,12 @@ int main(int, char**)
         T t(cuda::std::allocator_arg, A1<int>(), cuda::std::move(t0));
     }
     {
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         typedef cuda::std::tuple<MoveOnly> T;
         T t0(MoveOnly(0));
         T t(cuda::std::allocator_arg, A1<int>(), cuda::std::move(t0));
         assert(cuda::std::get<0>(t) == 0);
+#endif
     }
     {
         typedef cuda::std::tuple<alloc_first> T;
@@ -56,6 +58,7 @@ int main(int, char**)
 // testing extensions
 #ifdef _LIBCUDACXX_VERSION
     {
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         typedef cuda::std::tuple<MoveOnly, alloc_first> T;
         T t0(0 ,1);
         alloc_first::allocator_constructed() = false;
@@ -63,8 +66,10 @@ int main(int, char**)
         assert(alloc_first::allocator_constructed());
         assert(cuda::std::get<0>(t) == 0);
         assert(cuda::std::get<1>(t) == 1);
+#endif
     }
     {
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         typedef cuda::std::tuple<MoveOnly, alloc_first, alloc_last> T;
         T t0(1, 2, 3);
         alloc_first::allocator_constructed() = false;
@@ -75,6 +80,7 @@ int main(int, char**)
         assert(cuda::std::get<0>(t) == 1);
         assert(cuda::std::get<1>(t) == 2);
         assert(cuda::std::get<2>(t) == 3);
+#endif
     }
 #endif
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move_pair.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/alloc_move_pair.pass.cpp
@@ -13,7 +13,9 @@
 // template <class Alloc, class U1, class U2>
 //   tuple(allocator_arg_t, const Alloc& a, pair<U1, U2>&&);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_Types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_Types.pass.cpp
@@ -14,7 +14,9 @@
 
 // explicit tuple(const T&...);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_Types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_Types.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_pair.pass.cpp
@@ -12,7 +12,9 @@
 
 // template <class U1, class U2> tuple(const pair<U1, U2>& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/const_pair.pass.cpp
@@ -14,7 +14,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_copy.pass.cpp
@@ -14,7 +14,7 @@
 
 // XFAIL: gcc-4.8, gcc-4.9
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>
@@ -149,9 +149,11 @@ int main(int, char**)
         static_assert(cuda::std::is_convertible<ExplicitTwo&&, ExplicitTwo>::value, "");
         static_assert(cuda::std::is_convertible<cuda::std::tuple<ExplicitTwo&&>&&, const cuda::std::tuple<ExplicitTwo>&>::value, "");
 
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         ExplicitTwo e;
         cuda::std::tuple<ExplicitTwo> t = cuda::std::tuple<ExplicitTwo&&>(cuda::std::move(e));
         ((void)t);
+#endif
     }
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_copy.pass.cpp
@@ -15,6 +15,8 @@
 // XFAIL: gcc-4.8, gcc-4.9
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_copy.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_move.pass.cpp
@@ -14,8 +14,10 @@
 
 // template <class... UTypes> tuple(tuple<UTypes...>&& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 // UNSUPPORTED: nvrtc
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_move.pass.cpp
@@ -17,7 +17,7 @@
 // UNSUPPORTED: c++98, c++03
 // UNSUPPORTED: nvrtc
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/copy.pass.cpp
@@ -12,7 +12,9 @@
 
 // tuple(const tuple& u) = default;
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/copy.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/copy.pass.cpp
@@ -14,7 +14,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/default.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/default.pass.cpp
@@ -14,7 +14,9 @@
 
 // explicit(see-below) constexpr tuple();
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/default.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/default.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/dtor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/dtor.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/dtor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/dtor.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move.pass.cpp
@@ -14,7 +14,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move.pass.cpp
@@ -12,7 +12,7 @@
 
 // tuple(tuple&& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -67,7 +67,9 @@ __host__ __device__ void test_sfinae() {
     }
     // args constructors
     {
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
         static_assert(cuda::std::is_constructible<Tup, Elem&&>::value, "");
+#endif
         static_assert(!cuda::std::is_constructible<Tup, Elem const&>::value, "");
         static_assert(!cuda::std::is_constructible<Tup, Elem&>::value, "");
     }
@@ -97,6 +99,7 @@ int main(int, char**)
         T t = cuda::std::move(t0);
         unused(t); // Prevent unused warning
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         typedef cuda::std::tuple<MoveOnly> T;
         T t0(MoveOnly(0));
@@ -127,6 +130,7 @@ int main(int, char**)
         d_t d2(static_cast<d_t &&>(d));
         unused(d2);
     }
+#endif
     {
         test_sfinae<move_only_ebo>();
         test_sfinae<move_only_large>();

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move.pass.cpp
@@ -13,6 +13,8 @@
 // tuple(tuple&& u);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move_pair.pass.cpp
@@ -12,7 +12,9 @@
 
 // template <class U1, class U2> tuple(pair<U1, U2>&& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move_pair.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/move_pair.pass.cpp
@@ -14,7 +14,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/nothrow_cnstr.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/nothrow_cnstr.pass.cpp
@@ -13,6 +13,8 @@
 // tuple(tuple&& u);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // XFAIL: gcc-8 && c++17
 // XFAIL: gcc-7 && c++17

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/nothrow_cnstr.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/nothrow_cnstr.pass.cpp
@@ -14,7 +14,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // XFAIL: gcc-8 && c++17
 // XFAIL: gcc-7 && c++17

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/tuple_array_template_depth.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/tuple_array_template_depth.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/tuple_array_template_depth.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/tuple_array_template_depth.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/forward_as_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/forward_as_tuple.pass.cpp
@@ -13,7 +13,7 @@
 // template<class... Types>
 //     tuple<Types&&...> forward_as_tuple(Types&&... t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>
@@ -66,9 +66,11 @@ int main(int, char**)
     {
         test0(cuda::std::forward_as_tuple());
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         test1a(cuda::std::forward_as_tuple(1));
     }
+#endif
     {
         int i = 2;
         test1b(cuda::std::forward_as_tuple(i));

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/forward_as_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/forward_as_tuple.pass.cpp
@@ -14,6 +14,8 @@
 //     tuple<Types&&...> forward_as_tuple(Types&&... t);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/forward_as_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/forward_as_tuple.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/make_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/make_tuple.pass.cpp
@@ -15,7 +15,9 @@
 // template<class... Types>
 //   tuple<VTypes...> make_tuple(Types&&... t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/functional>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/make_tuple.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/make_tuple.pass.cpp
@@ -17,7 +17,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/functional>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tie.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tie.pass.cpp
@@ -17,7 +17,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tie.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tie.pass.cpp
@@ -15,7 +15,9 @@
 // template<class... Types>
 //   tuple<Types&...> tie(Types&... t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
@@ -15,6 +15,8 @@
 // template <class... Tuples> tuple<CTypes...> tuple_cat(Tuples&&... tpls);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
@@ -14,7 +14,7 @@
 
 // template <class... Tuples> tuple<CTypes...> tuple_cat(Tuples&&... tpls);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -80,6 +80,7 @@ int main(int, char**)
         unused(t); // Prevent unused warning
     }
     */
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         constexpr cuda::std::tuple<int> t1(1);
         constexpr cuda::std::tuple<int> t = cuda::std::tuple_cat(t1);
@@ -92,12 +93,15 @@ int main(int, char**)
         static_assert(cuda::std::get<1>(t) == 1, "");
     }
 #endif
+#endif
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         cuda::std::tuple<int, MoveOnly> t =
                                 cuda::std::tuple_cat(cuda::std::tuple<int, MoveOnly>(1, 2));
         assert(cuda::std::get<0>(t) == 1);
         assert(cuda::std::get<1>(t) == 2);
     }
+#endif
     // cuda::std::array not supported
     /*
     {
@@ -107,12 +111,13 @@ int main(int, char**)
         assert(cuda::std::get<2>(t) == 0);
     }
     */
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         cuda::std::tuple<int, MoveOnly> t = cuda::std::tuple_cat(cuda::std::pair<int, MoveOnly>(2, 1));
         assert(cuda::std::get<0>(t) == 2);
         assert(cuda::std::get<1>(t) == 1);
     }
-
+#endif
     {
         cuda::std::tuple<> t1;
         cuda::std::tuple<> t2;
@@ -161,6 +166,7 @@ int main(int, char**)
         assert(cuda::std::get<1>(t3) == 3.5);
         assert(cuda::std::get<2>(t3) == nullptr);
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         cuda::std::tuple<int*, MoveOnly> t1(nullptr, 1);
         cuda::std::tuple<int, double> t2(2, 3.5);
@@ -271,5 +277,6 @@ int main(int, char**)
             int, const int, int&, const int&>);
         unused(r);
     }
+#endif
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const.pass.cpp
@@ -16,7 +16,9 @@
 //   typename tuple_element<I, tuple<Types...> >::type const&
 //   get(const tuple<Types...>& t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const.pass.cpp
@@ -18,7 +18,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const_rv.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const_rv.pass.cpp
@@ -18,7 +18,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const_rv.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const_rv.pass.cpp
@@ -16,7 +16,7 @@
 //   const typename tuple_element<I, tuple<Types...> >::type&&
 //   get(const tuple<Types...>&& t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -64,6 +64,7 @@ int main(int, char**)
     static_assert(noexcept(cuda::std::get<1>(cuda::std::move(p))), "");
     }
 
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
     int x = 42;
     int const y = 43;
@@ -73,6 +74,7 @@ int main(int, char**)
     static_assert(cuda::std::is_same<int const&&, decltype(cuda::std::get<1>(cuda::std::move(p)))>::value, "");
     static_assert(noexcept(cuda::std::get<1>(cuda::std::move(p))), "");
     }
+#endif
 
 #if TEST_STD_VER > 11
     {

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const_rv.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_const_rv.pass.cpp
@@ -17,6 +17,8 @@
 //   get(const tuple<Types...>&& t);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
@@ -14,7 +14,9 @@
 //   typename tuple_element<I, tuple<Types...> >::type&
 //   get(tuple<Types...>& t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_non_const.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
@@ -14,7 +14,7 @@
 //   typename tuple_element<I, tuple<Types...> >::type&&
 //   get(tuple<Types...>&& t);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -36,10 +36,12 @@ int main(int, char**)
         assert(*p == 3);
     }
     */
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         cuda::std::tuple<MoveOnly> t(3);
         MoveOnly _m = cuda::std::get<0>(cuda::std::move(t));
         assert(_m.get() == 3);
     }
+#endif
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/get_rv.pass.cpp
@@ -15,6 +15,8 @@
 //   get(tuple<Types...>&& t);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
@@ -8,7 +8,7 @@
 
 
 
-// UNSUPPORTED: c++98, c++03, c++11 
+// UNSUPPORTED: c++98, c++03, c++11
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
@@ -88,6 +88,7 @@ int main(int, char**)
     static_assert(noexcept(cuda::std::get<int const&>(cuda::std::move(t))), "");
     }
 
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
     int x = 42;
     int y = 43;
@@ -97,7 +98,7 @@ int main(int, char**)
     static_assert(cuda::std::is_same<int const&&, decltype(cuda::std::get<int const&&>(cuda::std::move(t)))>::value, "");
     static_assert(noexcept(cuda::std::get<int const&&>(cuda::std::move(t))), "");
     }
-
+#endif
     {
     constexpr const cuda::std::tuple<int, const int, double, double> t { 1, 2, 3.4, 5.6 };
     static_assert(cuda::std::get<int>(cuda::std::move(t)) == 1, "");

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
@@ -9,6 +9,8 @@
 
 
 // UNSUPPORTED: c++98, c++03, c++11
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.elem/tuple.by.type.pass.cpp
@@ -10,7 +10,7 @@
 
 // UNSUPPORTED: c++98, c++03, c++11
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple.include.array.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple.include.array.pass.cpp
@@ -21,7 +21,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 // cuda::std::array not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple.include.array.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple.include.array.pass.cpp
@@ -19,7 +19,9 @@
 //  LWG #2212 says that tuple_size and tuple_element must be
 //     available after including <utility>
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 // cuda::std::array not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.pass.cpp
@@ -16,7 +16,9 @@
 //     typedef Ti type;
 // };
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.pass.cpp
@@ -18,7 +18,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size.pass.cpp
@@ -14,7 +14,9 @@
 //   class tuple_size<tuple<Types...>>
 //     : public integral_constant<size_t, sizeof...(Types)> { };
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_incomplete.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_incomplete.pass.cpp
@@ -18,7 +18,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 // cuda::std::array not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_incomplete.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_incomplete.pass.cpp
@@ -16,7 +16,9 @@
 
 // XFAIL: gcc-4.8, gcc-4.9
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 // cuda::std::array not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_v.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_v.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++98, c++03, c++11, c++14
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_v.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_v.pass.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03, c++11, c++14 
+// UNSUPPORTED: c++98, c++03, c++11, c++14
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_value_sfinae.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_value_sfinae.pass.cpp
@@ -16,7 +16,9 @@
 
 // XFAIL: gcc-4.8, gcc-4.9
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_value_sfinae.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_value_sfinae.pass.cpp
@@ -18,7 +18,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/eq.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/eq.pass.cpp
@@ -16,7 +16,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/eq.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/eq.pass.cpp
@@ -14,7 +14,9 @@
 //   bool
 //   operator==(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/lt.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/lt.pass.cpp
@@ -28,7 +28,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/lt.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.rel/lt.pass.cpp
@@ -26,7 +26,9 @@
 //   bool
 //   operator>=(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 // cuda::std::string not supported

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.special/non_member_swap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.special/non_member_swap.pass.cpp
@@ -14,6 +14,8 @@
 //   void swap(tuple<Types...>& x, tuple<Types...>& y);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.special/non_member_swap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.special/non_member_swap.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.special/non_member_swap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.special/non_member_swap.pass.cpp
@@ -13,7 +13,7 @@
 // template <class... Types>
 //   void swap(tuple<Types...>& x, tuple<Types...>& y);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>
@@ -29,6 +29,7 @@ int main(int, char**)
         T t1;
         swap(t0, t1);
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         typedef cuda::std::tuple<MoveOnly> T;
         T t0(MoveOnly(0));
@@ -59,6 +60,6 @@ int main(int, char**)
         assert(cuda::std::get<1>(t1) == 1);
         assert(cuda::std::get<2>(t1) == 2);
     }
-
+#endif
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.swap/member_swap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.swap/member_swap.pass.cpp
@@ -13,6 +13,8 @@
 // void swap(tuple& rhs);
 
 // UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.swap/member_swap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.swap/member_swap.pass.cpp
@@ -12,7 +12,7 @@
 
 // void swap(tuple& rhs);
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>
@@ -28,6 +28,7 @@ int main(int, char**)
         T t1;
         t0.swap(t1);
     }
+#if !(defined(_MSC_VER) && _MSC_VER < 1916)
     {
         typedef cuda::std::tuple<MoveOnly> T;
         T t0(MoveOnly(0));
@@ -58,6 +59,6 @@ int main(int, char**)
         assert(cuda::std::get<1>(t1) == 1);
         assert(cuda::std::get<2>(t1) == 2);
     }
-
+#endif
   return 0;
 }

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.swap/member_swap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.swap/member_swap.pass.cpp
@@ -14,7 +14,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/cassert>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.traits/uses_allocator.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.traits/uses_allocator.pass.cpp
@@ -13,7 +13,9 @@
 // template <class... Types, class Alloc>
 //   struct uses_allocator<tuple<Types...>, Alloc> : true_type { };
 
-// UNSUPPORTED: c++98, c++03 
+// UNSUPPORTED: c++98, c++03
+// Internal compiler error in 14.24
+// XFAIL: msvc-19.24
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.traits/uses_allocator.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.traits/uses_allocator.pass.cpp
@@ -15,7 +15,7 @@
 
 // UNSUPPORTED: c++98, c++03
 // Internal compiler error in 14.24
-// XFAIL: msvc-19.24
+// XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>

--- a/include/cuda/std/detail/libcxx/include/atomic
+++ b/include/cuda/std/detail/libcxx/include/atomic
@@ -1239,7 +1239,7 @@ _LIBCUDACXX_INLINE_VISIBILITY void __cxx_atomic_wait(__cxx_atomic_impl<_Tp, _Sco
 }
 
 // general atomic<T>/atomic_ref<T>
-template <class _Tp, int _Sco = 0, bool = is_integral<_Tp>() && !is_same<_Tp, bool>()>
+template <class _Tp, int _Sco = 0, bool = is_integral<_Tp>::value && !is_same<_Tp, bool>::value>
 struct __atomic_base {
     mutable __cxx_atomic_impl<_Tp, _Sco> __a_;
 

--- a/include/cuda/std/detail/libcxx/include/chrono
+++ b/include/cuda/std/detail/libcxx/include/chrono
@@ -1699,7 +1699,7 @@ bool operator>=(const day& __lhs, const day& __rhs) noexcept
 _LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
 day operator+ (const day& __lhs, const days& __rhs) noexcept
-{ return day(static_cast<unsigned>(__lhs) + __rhs.count()); }
+{ return day(static_cast<unsigned>(__lhs) + static_cast<unsigned>(__rhs.count())); }
 
 _LIBCUDACXX_INLINE_VISIBILITY
 inline constexpr
@@ -2534,7 +2534,7 @@ year_month_day::__from_days(days __d) noexcept
     const unsigned __doy = __doe - (365 * __yoe + __yoe/4 - __yoe/100);              // [0, 365]
     const unsigned __mp = (5 * __doy + 2)/153;                                       // [0, 11]
     const unsigned __dy = __doy - (153 * __mp + 2)/5 + 1;                            // [1, 31]
-    const unsigned __mth = __mp + (__mp < 10 ? 3 : -9);                              // [1, 12]
+    const unsigned __mth = __mp + static_cast<unsigned>(__mp < 10 ? 3 : -9);       // [1, 12]
     return year_month_day{chrono::year{__yr + (__mth <= 2)}, chrono::month{__mth}, chrono::day{__dy}};
 }
 
@@ -2553,9 +2553,9 @@ inline constexpr days year_month_day::__to_days() const noexcept
     const unsigned __dy  = static_cast<unsigned>(__d);
 
     const int      __era = (__yr >= 0 ? __yr : __yr - 399) / 400;
-    const unsigned __yoe = static_cast<unsigned>(__yr - __era * 400);                // [0, 399]
-    const unsigned __doy = (153 * (__mth + (__mth > 2 ? -3 : 9)) + 2) / 5 + __dy-1;  // [0, 365]
-    const unsigned __doe = __yoe * 365 + __yoe/4 - __yoe/100 + __doy;                // [0, 146096]
+    const unsigned __yoe = static_cast<unsigned>(__yr - __era * 400);                  // [0, 399]
+    const unsigned __doy = static_cast<unsigned>((153 * (__mth + static_cast<unsigned>(__mth > 2 ? -3 : 9)) + 2) / 5 + __dy-1);  // [0, 365]
+    const unsigned __doe = __yoe * 365 + __yoe/4 - __yoe/100 + __doy;                  // [0, 146096]
     return days{__era * 146097 + static_cast<int>(__doe) - 719468};
 }
 

--- a/include/cuda/std/detail/libcxx/include/chrono
+++ b/include/cuda/std/detail/libcxx/include/chrono
@@ -2534,7 +2534,7 @@ year_month_day::__from_days(days __d) noexcept
     const unsigned __doy = __doe - (365 * __yoe + __yoe/4 - __yoe/100);              // [0, 365]
     const unsigned __mp = (5 * __doy + 2)/153;                                       // [0, 11]
     const unsigned __dy = __doy - (153 * __mp + 2)/5 + 1;                            // [1, 31]
-    const unsigned __mth = __mp + static_cast<unsigned>(__mp < 10 ? 3 : -9);       // [1, 12]
+    const unsigned __mth = __mp + static_cast<unsigned>(__mp < 10 ? 3 : -9);         // [1, 12]
     return year_month_day{chrono::year{__yr + (__mth <= 2)}, chrono::month{__mth}, chrono::day{__dy}};
 }
 
@@ -2554,7 +2554,8 @@ inline constexpr days year_month_day::__to_days() const noexcept
 
     const int      __era = (__yr >= 0 ? __yr : __yr - 399) / 400;
     const unsigned __yoe = static_cast<unsigned>(__yr - __era * 400);                  // [0, 399]
-    const unsigned __doy = static_cast<unsigned>((153 * (__mth + static_cast<unsigned>(__mth > 2 ? -3 : 9)) + 2) / 5 + __dy-1);  // [0, 365]
+    const unsigned __doy = static_cast<unsigned>(
+        (153 * (__mth + static_cast<unsigned>(__mth > 2 ? -3 : 9)) + 2) / 5 + __dy-1); // [0, 365]
     const unsigned __doe = __yoe * 365 + __yoe/4 - __yoe/100 + __doy;                  // [0, 146096]
     return days{__era * 146097 + static_cast<int>(__doe) - 719468};
 }


### PR DESCRIPTION
This commit chain will include fixes to address failures detected across several versions of MSVC. I've used the compilers listed below that I believe are major releases for MSVC. 

## MSVC versions that are clean:
- [x] 14.12
- [x] 14.13
- [x] 14.16
- [x] 14.22
- [x] 14.24 
- [x] 14.27 
- [x] 14.29
- [x] 14.30