### PR TITLE
CTAD is passing on clang 9 and clang 10

### DIFF
--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp
@@ -20,7 +20,7 @@
 // UNSUPPORTED: nvrtc
 
 // Currently broken with Clang + NVCC.
-// XFAIL: clang-6, clang-7, clang-9, clang-10
+// XFAIL: clang-6, clang-7
 
 // <cuda/std/tuple>
 

--- a/.upstream-tests/test/std/utilities/utility/pairs/pairs.pair/implicit_deduction_guides.pass.cpp
+++ b/.upstream-tests/test/std/utilities/utility/pairs/pairs.pair/implicit_deduction_guides.pass.cpp
@@ -18,7 +18,7 @@
 // XFAIL: gcc
 
 // Currently broken with Clang + NVCC.
-// XFAIL: clang-6, clang-7, clang-9, clang-10
+// XFAIL: clang-6, clang-7
 
 // <utility>
 


### PR DESCRIPTION
Seems that NVCC fixed a template deduction mixup or something. These tests are passing and I've updated the XFAIL list to reflect that.