### PR TITLE
Fix device code path in <nv/target> when compiling with clang-cuda

### DIFF
--- a/include/nv/detail/__target_macros
+++ b/include/nv/detail/__target_macros
@@ -78,7 +78,7 @@
 #  define _NV_TARGET_PROVIDES(q)   nv::target::provides(q)
 #  define _NV_TARGET_IS_EXACTLY(q) nv::target::is_exactly(q)
 
-#elif defined(_NV_COMPILER_NVCC)
+#elif defined(_NV_COMPILER_NVCC) || defined (_NV_COMPILER_CLANG_CUDA)
 
 #  define _NV_TARGET_VAL_SM_35 350
 #  define _NV_TARGET_VAL_SM_37 370
@@ -229,7 +229,7 @@
       _NV_BLOCK_EXPAND(t)        \
     } else { _NV_BLOCK_EXPAND(__VA_ARGS__) })
 
-#elif defined(_NV_COMPILER_NVCC)
+#elif defined(_NV_COMPILER_NVCC) || defined (_NV_COMPILER_CLANG_CUDA)
 
 #  if (_NV_TARGET___NV_IS_EXACTLY_SM_35)
 #    define _NV_TARGET_BOOL___NV_IS_EXACTLY_SM_35 1

--- a/include/nv/target
+++ b/include/nv/target
@@ -18,6 +18,9 @@
 #  define _NV_COMPILER_NVCC
 #elif defined(__NVCOMPILER) && __cplusplus >= 201103L
 #  define _NV_COMPILER_NVCXX
+#elif defined(__clang__) && defined(__CUDA__) && defined(__CUDA_ARCH__)
+// clang compiling CUDA code, device mode.
+#  define _NV_COMPILER_CLANG_CUDA
 #endif
 
 #if defined(__CUDACC_RTC__)


### PR DESCRIPTION
Fixes https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3611649&cmtNo=