### PR TITLE
Fix pedantic warnings in <nv/target> on IBM xlc.

### DIFF
--- a/include/nv/detail/__target_macros
+++ b/include/nv/detail/__target_macros
@@ -456,7 +456,7 @@
 #  define _NV_TARGET_DISPATCH(...) _NV_BLOCK_EXPAND(_NV_DISPATCH_N_ARY(_NV_TARGET_DISPATCH_HANDLE, __VA_ARGS__))
 
 // NV_IF_TARGET supports a false statement provided as a variadic macro
-#  define NV_IF_TARGET(cond, t, ...)    _NV_BLOCK_EXPAND(_NV_TARGET_IF(cond, t, __VA_ARGS__))
+#  define NV_IF_TARGET(cond, ...)    _NV_BLOCK_EXPAND(_NV_TARGET_IF(cond, __VA_ARGS__))
 #  define NV_IF_ELSE_TARGET(cond, t, f) _NV_BLOCK_EXPAND(_NV_TARGET_IF(cond, t, f))
 #  define NV_DISPATCH_TARGET(...)       _NV_TARGET_DISPATCH(__VA_ARGS__)
 

--- a/include/nv/target
+++ b/include/nv/target
@@ -35,8 +35,9 @@
 #  define _NV_BITSET_ATTRIBUTE
 #endif
 
-#if (defined(__cplusplus) && __cplusplus >= 201103L) || \
-    (defined(_MSC_VER) && _MSVC_LANG >= 201103L)
+#if (!defined(__ibmxl__)) && \
+    ((defined(__cplusplus) && __cplusplus >= 201103L) || \
+     (defined(_MSC_VER) && _MSVC_LANG >= 201103L))
 #  define _NV_TARGET_CPP11
 #endif
 


### PR DESCRIPTION
Forces IBM compiler to use fallback C98 path with no variadic macros.


https://scbuilds4u/dvs/#/change/3130351639432407.1?eventType=Virtual
https://builds4u.nvidia.com/dvs/#/change/3130459861768104.2?eventType=Virtual