### PR TITLE
Prevent usage of cuda::atomic::fetch_max/min for non-integral types.

### DIFF
--- a/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_fetch.fail.cpp
+++ b/.upstream-tests/test/cuda/atomics/atomic.ext/atomic_fetch.fail.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70, nvrtc
+
+// <cuda/std/atomic>
+
+#include <cuda/std/atomic>
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "atomic_helpers.h"
+#include "cuda_space_selector.h"
+
+template <class T, template<typename, typename> typename Selector, cuda::thread_scope>
+struct TestFn {
+  __host__ __device__
+  void operator()() const {
+    {
+        typedef cuda::atomic<T> A;
+        Selector<A, constructor_initializer> sel;
+        A & t = *sel.construct();
+        t.fetch_min(4);
+    }
+    {
+        typedef cuda::atomic<T> A;
+        Selector<volatile A, constructor_initializer> sel;
+        volatile A & t = *sel.construct();
+        t.fetch_max(4);
+    }
+    T tmp = T(0);
+    {
+        cuda::atomic_ref<T> t(tmp);
+        t.fetch_min(4);
+    }
+    {
+        cuda::atomic_ref<T> t(tmp);
+        t.fetch_max(4);
+    }
+  }
+};
+
+int main(int, char**)
+{
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
+    TestFn<float, local_memory_selector, cuda::thread_scope::thread_scope_thread>()();
+#endif
+#ifdef __CUDA_ARCH__
+    TestFn<float, shared_memory_selector, cuda::thread_scope::thread_scope_thread>()();
+    TestFn<float, global_memory_selector, cuda::thread_scope::thread_scope_thread>()();
+#endif
+
+  return 0;
+}

--- a/include/cuda/std/atomic
+++ b/include/cuda/std/atomic
@@ -101,12 +101,14 @@ struct atomic
     __host__ __device__
     _Tp fetch_max(const _Tp & __op, memory_order __m = memory_order_seq_cst) volatile noexcept
     {
+        static_assert(std::is_integral<_Tp>(), "fetch_max/min is available for integral types only");
         return std::__detail::__cxx_atomic_fetch_max(&this->__a_, __op, __m);
     }
 
     __host__ __device__
     _Tp fetch_min(const _Tp & __op, memory_order __m = memory_order_seq_cst) volatile noexcept
     {
+        static_assert(std::is_integral<_Tp>(), "fetch_max/min is available for integral types only");
         return std::__detail::__cxx_atomic_fetch_min(&this->__a_, __op, __m);
     }
 };
@@ -192,12 +194,14 @@ struct atomic_ref
     __host__ __device__
     _Tp fetch_max(const _Tp & __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
     {
+        static_assert(std::is_integral<_Tp>(), "fetch_max/min is available for integral types only");
         return std::__detail::__cxx_atomic_fetch_max(&this->__a_, __op, __m);
     }
 
     __host__ __device__
     _Tp fetch_min(const _Tp & __op, memory_order __m = memory_order_seq_cst) const volatile noexcept
     {
+        static_assert(std::is_integral<_Tp>(), "fetch_max/min is available for integral types only");
         return std::__detail::__cxx_atomic_fetch_min(&this->__a_, __op, __m);
     }
 };


### PR DESCRIPTION
I've used a `static_assert` instead of adding a proper inheritance layer. This should serve as a temporary stop-gap and provide meaningful output for users if they attempt to use `fetch_max/min` on non-integral types.

This doesn't seem to impact other units and the output is somewhat understandable.

```
C:/sbf/libcudacxx/include\cuda/std/atomic(111): error: static assertion failed with "fetch_max/min is available for integral types only"
          detected during:
            instantiation of "_Tp cuda::__4::atomic<_Tp, _Sco>::fetch_min(const _Tp &, cuda::__4::memory_order) volatile noexcept [with _Tp=float, _Sco=cuda::std::__4::__detail::thread_scope_system]"
C:\sbf\libcudacxx\.upstream-tests\test\cuda\atomics\atomic.ext\atomic_fetch.fail.cpp(30): here
            instantiation of "void TestFn<T, Selector, <unnamed>>::operator()() const [with T=float, Selector=local_memory_selector, <unnamed>=cuda::std::__4::__detail::thread_scope_thread]"
C:\sbf\libcudacxx\.upstream-tests\test\cuda\atomics\atomic.ext\atomic_fetch.fail.cpp(53): here
```