### PR TITLE
Invoke result extended lambdas support

### DIFF
--- a/.upstream-tests/test/cuda/proclaim_return_type.fail.cpp
+++ b/.upstream-tests/test/cuda/proclaim_return_type.fail.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+// UNSUPPORTED: nvrtc, gcc-4
+
+#include <cuda/functional>
+
+#include <assert.h>
+
+int main(int argc, char ** argv)
+{
+#ifdef __CUDA_ARCH__
+  auto f = cuda::proclaim_return_type<double>(
+      [] __device__ () -> int { return 42; });
+
+  assert(f() == 42);
+#else
+#error shall fail
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
+++ b/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+// UNSUPPORTED: gcc-4
+
+#include <cuda/functional>
+
+#include <assert.h>
+
+template <class T, class Fn, class... As>
+__host__ __device__
+void test_proclaim_return_type(Fn&& fn, T expected, As... as)
+{
+  {
+    auto f = cuda::proclaim_return_type<T>(cuda::std::forward<Fn>(fn));
+
+    assert(f(as...) == expected);
+    assert(cuda::std::move(f)(as...) == expected);
+  }
+
+  {
+    const auto f = cuda::proclaim_return_type<T>(fn);
+
+    assert(f(as...) == expected);
+    assert(cuda::std::move(f)(as...) == expected);
+  }
+}
+
+struct hd_callable
+{
+  __host__ __device__ int operator()() const& { return 42; }
+  __host__ __device__ int operator()() const&& { return 42; }
+};
+
+struct h_callable
+{
+  __host__ int operator()() const& { return 42; }
+  __host__ int operator()() const&& { return 42; }
+};
+
+struct d_callable
+{
+  __device__ int operator()() const& { return 42; }
+  __device__ int operator()() const&& { return 42; }
+};
+
+int main(int argc, char ** argv)
+{
+#ifdef __CUDA_ARCH__
+#define TEST_SPECIFIER(...)                                                    \
+  {                                                                            \
+    test_proclaim_return_type<double>([] __VA_ARGS__ () { return 42.0; },      \
+                                      42.0);                                   \
+    test_proclaim_return_type<int>([] __VA_ARGS__ (int v) { return v * 2; },   \
+                                   42, 21);                                    \
+                                                                               \
+    int v = 42;                                                                \
+    int* vp = &v;                                                              \
+    test_proclaim_return_type<int&>(                                           \
+        [vp] __VA_ARGS__ () -> int& { return *vp; }, v);                       \
+  }
+
+  TEST_SPECIFIER(__device__)
+  TEST_SPECIFIER(__host__ __device__)
+  TEST_SPECIFIER()
+#undef TEST_SPECIFIER
+  
+  test_proclaim_return_type<int>(hd_callable{}, 42);                                   
+  test_proclaim_return_type<int>(d_callable{}, 42);                                   
+#else
+  test_proclaim_return_type<int>(h_callable{}, 42);                                   
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.fail.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.fail.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Mandates: invoke result must fail to compile when used with device lambdas.
+// UNSUPPORTED: !nvcc
+
+// <cuda/std/functional>
+
+// result_of<Fn(ArgTypes...)>
+
+#include <cuda/std/type_traits>
+#include <cuda/std/cassert>
+#include "test_macros.h"
+
+
+template <class Ret, class Fn>
+__host__ __device__
+void test_lambda(Fn &&)
+{
+    ASSERT_SAME_TYPE(Ret, typename cuda::std::result_of<Fn()>::type);
+
+#if TEST_STD_VER > 11
+    ASSERT_SAME_TYPE(Ret, typename cuda::std::invoke_result<Fn>::type);
+#endif
+}
+
+int main(int, char**)
+{
+#if defined(__NVCC__) 
+    { // extended device lambda
+    test_lambda<int>([] __device__ () -> int { return 42; });
+    test_lambda<double>([] __device__ () -> double { return 42.0; });
+    }
+#endif
+
+  return 0;
+}

--- a/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.fail.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.fail.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // Mandates: invoke result must fail to compile when used with device lambdas.
-// UNSUPPORTED: !nvcc
+// UNSUPPORTED: nvrtc
 
 // <cuda/std/functional>
 

--- a/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.pass.cpp
@@ -13,6 +13,7 @@
 #include <cuda/std/type_traits>
 // #include <cuda/std/memory>
 #include <cuda/std/cassert>
+#include <cuda/functional>
 #include "test_macros.h"
 
 struct S
@@ -101,6 +102,7 @@ void test_no_result()
 #endif
 }
 
+#if defined(__NVCC__) 
 template <class Ret, class Fn>
 __host__ __device__
 void test_lambda(Fn &&)
@@ -111,6 +113,7 @@ void test_lambda(Fn &&)
     ASSERT_SAME_TYPE(Ret, typename cuda::std::invoke_result<Fn>::type);
 #endif
 }
+#endif
 
 int main(int, char**)
 {
@@ -422,9 +425,13 @@ int main(int, char**)
     }
 #if defined(__NVCC__) 
     { // extended lambda
+#if defined(__CUDA_ARCH__)
     test_lambda<int>([] __host__ __device__ () -> int { return 42; });
     test_lambda<double>([] __host__ __device__ () -> double { return 42.0; });
     test_lambda<SD>([] __host__ __device__ () -> SD { return {}; });
+#endif
+    test_lambda<double>(cuda::proclaim_return_type<double>(
+        [] __device__ () -> double { return 42.0; }));
     }
 #endif
 

--- a/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.trans/meta.trans.other/result_of.pass.cpp
@@ -101,6 +101,17 @@ void test_no_result()
 #endif
 }
 
+template <class Ret, class Fn>
+__host__ __device__
+void test_lambda(Fn &&)
+{
+    ASSERT_SAME_TYPE(Ret, typename cuda::std::result_of<Fn()>::type);
+
+#if TEST_STD_VER > 11
+    ASSERT_SAME_TYPE(Ret, typename cuda::std::invoke_result<Fn>::type);
+#endif
+}
+
 int main(int, char**)
 {
     typedef NotDerived ND;
@@ -409,6 +420,13 @@ int main(int, char**)
 #endif
     test_no_result<PMD(ND&)>();
     }
+#if defined(__NVCC__) 
+    { // extended lambda
+    test_lambda<int>([] __host__ __device__ () -> int { return 42; });
+    test_lambda<double>([] __host__ __device__ () -> double { return 42.0; });
+    test_lambda<SD>([] __host__ __device__ () -> SD { return {}; });
+    }
+#endif
 
   return 0;
 }

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 gem "just-the-docs"
 group :jekyll_plugins do
+  gem "webrick"                 
   gem "github-pages"                 # GitHub Pages.
   gem "jekyll-optional-front-matter" # GitHub Pages.
   gem "jekyll-default-layout"        # GitHub Pages.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -92,6 +92,14 @@ defaults:
       nav_order: 5
   -
     scope:
+      path: extended_api/functional.md
+    values:
+      parent: Extended API
+      has_children: true
+      has_toc: false
+      nav_order: 6
+  -
+    scope:
       path: releases/changelog.md
     values:
       parent: Releases

--- a/docs/extended_api.md
+++ b/docs/extended_api.md
@@ -19,6 +19,8 @@ nav_order: 3
 
 {% include_relative extended_api/memory_access_properties.md %}
 
+{% include_relative extended_api/functional.md %}
+
 [Thread Scopes]: ./extended_api/thread_scopes.md
 [Thread Groups]: ./extended_api/thread_groups.md
 

--- a/docs/extended_api/functional.md
+++ b/docs/extended_api/functional.md
@@ -1,0 +1,7 @@
+## Functional
+
+| [`cuda::proclaim_return_type`] | Creates a forwarding call wrapper that proclaims return type <br/><br/> 1.8.0 / CUDA 11.7 |
+
+
+[`cuda::proclaim_return_type`]: {{ "extended_api/functional/proclaim_return_type.html" | relative_url }}
+

--- a/docs/extended_api/functional/proclaim_return_type.md
+++ b/docs/extended_api/functional/proclaim_return_type.md
@@ -1,0 +1,55 @@
+---
+grand_parent: Extended API
+parent: Functional
+---
+
+# `cuda::proclaim_return_type`
+
+Defined in the header `<cuda/functional>`:
+
+```cuda
+template <class Ret, class Fn>
+__host__ __device__
+unspecified<Ret, Fn> proclaim_return_type(Fn&& fn) {
+  return unspecified<Ret, Fn>{fn};
+}
+```
+
+`cuda::proclaim_return_type` creates a forwarding call wrapper that uses
+`Ret` as a return type. The wrapper is useful in the case of extended device
+lambdas since an attempt to determine the return type of their `operator()` 
+function may work incorrectly in host code.
+
+## Template Parameters
+
+| `Ret` | Return type that's being proclaimed       |
+| `Fn`  | Callable object type that's being wrapped |
+
+## Parameters
+
+| `fn`  | Callable object that's being wrapped |
+
+## Example
+
+```cuda
+#include <cuda/functional>
+
+template <class T, class Fn>
+__global__ void example_kernel(T *out, Fn fn) {
+  *out = fn();
+}
+
+__host__ void example() {
+  auto fn = cuda::proclaim_return_type<char>([] __device__ () { return 'd'; });
+  using rt = cuda::std::invoke_result_t<decltype(fn)>;
+
+  rt* out {}; 
+  cudaMalloc(&out, sizeof(rt));
+
+  example_kernel<<<1, 1>>>(out, fn);
+
+  // ...
+}
+
+```
+

--- a/include/cuda/functional
+++ b/include/cuda/functional
@@ -1,0 +1,155 @@
+// -*- C++ -*-
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * NVIDIA SOFTWARE LICENSE
+ *
+ * This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of the NVIDIA/CUDA C++ Library software and materials provided hereunder (“SOFTWARE”).
+ *
+ * This license can be accepted only by an adult of legal age of majority in the country in which the SOFTWARE is used. If you are under the legal age of majority, you must ask your parent or legal guardian to consent to this license. By taking delivery of the SOFTWARE, you affirm that you have reached the legal age of majority, you accept the terms of this license, and you take legal and financial responsibility for the actions of your permitted users.
+ *
+ * You agree to use the SOFTWARE only for purposes that are permitted by (a) this license, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions.
+ *
+ * 1. LICENSE. Subject to the terms of this license, NVIDIA grants you a non-exclusive limited license to: (a) install and use the SOFTWARE, and (b) distribute the SOFTWARE subject to the distribution requirements described in this license. NVIDIA reserves all rights, title and interest in and to the SOFTWARE not expressly granted to you under this license.
+ *
+ * 2. DISTRIBUTION REQUIREMENTS. These are the distribution requirements for you to exercise the distribution grant:
+ * a.      The terms under which you distribute the SOFTWARE must be consistent with the terms of this license, including (without limitation) terms relating to the license grant and license restrictions and protection of NVIDIA’s intellectual property rights.
+ * b.      You agree to notify NVIDIA in writing of any known or suspected distribution or use of the SOFTWARE not in compliance with the requirements of this license, and to enforce the terms of your agreements with respect to distributed SOFTWARE.
+ *
+ * 3. LIMITATIONS. Your license to use the SOFTWARE is restricted as follows:
+ * a.      The SOFTWARE is licensed for you to develop applications only for use in systems with NVIDIA GPUs.
+ * b.      You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from any portion of the SOFTWARE or copies of the SOFTWARE.
+ * c.      You may not modify or create derivative works of any portion of the SOFTWARE.
+ * d.      You may not bypass, disable, or circumvent any technical measure, encryption, security, digital rights management or authentication mechanism in the SOFTWARE.
+ * e.      You may not use the SOFTWARE in any manner that would cause it to become subject to an open source software license. As examples, licenses that require as a condition of use, modification, and/or distribution that the SOFTWARE be (i) disclosed or distributed in source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+ * f.      Unless you have an agreement with NVIDIA for this purpose, you may not use the SOFTWARE with any system or application where the use or failure of the system or application can reasonably be expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA does not design, test or manufacture the SOFTWARE for these critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or damages arising from such uses.
+ * g.      You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective employees, contractors, agents, officers and directors, from and against any and all claims, damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to use of the SOFTWARE outside of the scope of this Agreement, or not in compliance with its terms.
+ *
+ * 4. PRE-RELEASE. SOFTWARE versions identified as alpha, beta, preview, early access or otherwise as pre-release may not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy, availability, and reliability standards relative to commercial versions of NVIDIA software and materials. You may use a pre-release SOFTWARE version at your own risk, understanding that these versions are not intended for use in production or business-critical systems.
+ *
+ * 5. OWNERSHIP. The SOFTWARE and the related intellectual property rights therein are and will remain the sole and exclusive property of NVIDIA or its licensors. The SOFTWARE is copyrighted and protected by the laws of the United States and other countries, and international treaty provisions. NVIDIA may make changes to the SOFTWARE, at any time without notice, but is not obligated to support or update the SOFTWARE.
+ *
+ * 6. COMPONENTS UNDER OTHER LICENSES. The SOFTWARE may include NVIDIA or third-party components with separate legal notices or terms as may be described in proprietary notices accompanying the SOFTWARE. If and to the extent there is a conflict between the terms in this license and the license terms associated with a component, the license terms associated with the components control only to the extent necessary to resolve the conflict.
+ *
+ * 7. FEEDBACK. You may, but don’t have to, provide to NVIDIA any Feedback. “Feedback” means any suggestions, bug fixes, enhancements, modifications, feature requests or other feedback regarding the SOFTWARE. For any Feedback that you voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute (through multiple tiers of distributors) the Feedback without the payment of any royalties or fees to you. NVIDIA will use Feedback at its choice.
+ *
+ * 8. NO WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED WARRANTY OF ANY KIND INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ALL ERRORS WILL BE CORRECTED.
+ *
+ * 9. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR PERFORMANCE OF THE SOFTWARE, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT.
+ *
+ * 10. TERMINATION. Your rights under this license will terminate automatically without notice from NVIDIA if you fail to comply with any term and condition of this license or if you commence or participate in any legal proceeding against NVIDIA with respect to the SOFTWARE. NVIDIA may terminate this license with advance written notice to you if NVIDIA decides to no longer provide the SOFTWARE in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer commercially viable. Upon any termination of this license, you agree to promptly discontinue use of the SOFTWARE and destroy all copies in your possession or control. Your prior distributions in accordance with this license are not affected by the termination of this license. All provisions of this license will survive termination, except for the license granted to you.
+ *
+ * 11. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States and of the State of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English language. The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this license. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction.
+ *
+ * 12. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by you by any means or operation of law without NVIDIA’s permission. Any attempted assignment not approved by NVIDIA in writing shall be void and of no effect.
+ *
+ * 13. EXPORT. The SOFTWARE is subject to United States export laws and regulations. You agree that you will not ship, transfer or export the SOFTWARE into any country, or use the SOFTWARE in any manner, prohibited by the United States Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws include restrictions on destinations, end users and end use. By accepting this license, you confirm that you are not a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from receiving the SOFTWARE.
+ *
+ * 14. GOVERNMENT USE. The SOFTWARE has been developed entirely at private expense and is “commercial items” consisting of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS. Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the restrictions in this license pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
+ *
+ * 15. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the parties relating to the subject matter of this license and supersedes all prior or contemporaneous understandings and agreements relating to this subject matter, whether oral or written. If any court of competent jurisdiction determines that any provision of this license is illegal, invalid or unenforceable, the remaining provisions will remain in full force and effect. This license may only be modified in a writing signed by an authorized representative of each party.
+ *
+ * (v. August 20, 2021)
+ */
+
+#ifndef _CUDA_FUNCTIONAL_
+#define _CUDA_FUNCTIONAL_
+
+#include <cuda/std/type_traits>
+#include <cuda/std/functional>
+#include <cuda/std/utility>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+namespace __detail
+{
+
+template <class _Ret, class _DecayFn>
+class __return_type_wrapper {
+ private:
+  _DecayFn __fn_;
+
+ public:
+  __return_type_wrapper() = delete;
+
+  template <class _Fn>
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY 
+  explicit __return_type_wrapper(_Fn&& __fn) noexcept
+      : __fn_(_CUDA_VSTD::forward<_Fn>(__fn)) {}
+
+  template <class... _As>
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
+  operator()(_As&&... __as) & noexcept {
+#if !defined(__NVCC__) || defined(__CUDA_ARCH__)
+    static_assert(
+        _CUDA_VSTD::is_same<
+            _Ret, 
+            typename _CUDA_VSTD::__invoke_of<_DecayFn, _As...>::type
+          >::value,
+        "Return type shall match the proclaimed one exactly");
+#endif
+
+    return _CUDA_VSTD::__invoke(__fn_, _CUDA_VSTD::forward<_As>(__as)...);
+  }
+
+  template <class... _As>
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
+  operator()(_As&&... __as) && noexcept {
+#if !defined(__NVCC__) || defined(__CUDA_ARCH__)
+    static_assert(
+        _CUDA_VSTD::is_same<
+            _Ret, 
+            typename _CUDA_VSTD::__invoke_of<_DecayFn&&, _As...>::type
+          >::value,
+        "Return type shall match the proclaimed one exactly");
+#endif
+
+    return _CUDA_VSTD::__invoke(_CUDA_VSTD::move(__fn_),
+                                _CUDA_VSTD::forward<_As>(__as)...);
+  }
+
+  template <class... _As>
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
+  operator()(_As&&... __as) const& noexcept {
+#if !defined(__NVCC__) || defined(__CUDA_ARCH__)
+    static_assert(
+        _CUDA_VSTD::is_same<
+            _Ret, 
+            typename _CUDA_VSTD::__invoke_of<_DecayFn, _As...>::type
+          >::value,
+        "Return type shall match the proclaimed one exactly");
+#endif
+
+    return _CUDA_VSTD::__invoke(__fn_, _CUDA_VSTD::forward<_As>(__as)...);
+  }
+
+  template <class... _As>
+  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
+  operator()(_As&&... __as) const&& noexcept {
+#if !defined(__NVCC__) || defined(__CUDA_ARCH__)
+    static_assert(
+        _CUDA_VSTD::is_same<
+            _Ret, 
+            typename _CUDA_VSTD::__invoke_of<_DecayFn&&, _As...>::type
+          >::value,
+        "Return type shall match the proclaimed one exactly");
+#endif
+
+    return _CUDA_VSTD::__invoke(_CUDA_VSTD::move(__fn_),
+                                _CUDA_VSTD::forward<_As>(__as)...);
+  }
+};
+
+}  // __detail
+
+template <class _Ret, class _Fn>
+inline _LIBCUDACXX_INLINE_VISIBILITY
+__detail::__return_type_wrapper<_Ret, typename _CUDA_VSTD::decay<_Fn>::type>
+proclaim_return_type(_Fn&& __fn) noexcept {
+  return __detail::__return_type_wrapper<_Ret,
+                                         typename _CUDA_VSTD::decay<_Fn>::type>(
+      _CUDA_VSTD::forward<_Fn>(__fn));
+}
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#endif // _CUDA_FUNCTIONAL_
+

--- a/include/cuda/std/detail/libcxx/include/type_traits
+++ b/include/cuda/std/detail/libcxx/include/type_traits
@@ -4400,6 +4400,12 @@ struct __invoke_of
         __invokable<_Fp, _Args...>::value,
         typename __invokable_r<void, _Fp, _Args...>::_Result>
 {
+  #if defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) && !defined(__CUDA_ARCH__)
+    static_assert(!__nv_is_extended_device_lambda_closure_type(_Fp),
+                  "Attempt to use an extended __device__ lambda in a context "
+                  "that requires querying its return type. Use a named "
+                  "function object or a __host__ __device__ lambda instead.");
+  #endif
 };
 
 // result_of

--- a/include/cuda/std/detail/libcxx/include/type_traits
+++ b/include/cuda/std/detail/libcxx/include/type_traits
@@ -4400,12 +4400,14 @@ struct __invoke_of
         __invokable<_Fp, _Args...>::value,
         typename __invokable_r<void, _Fp, _Args...>::_Result>
 {
-  #if defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) && !defined(__CUDA_ARCH__)
-    static_assert(!__nv_is_extended_device_lambda_closure_type(_Fp),
-                  "Attempt to use an extended __device__ lambda in a context "
-                  "that requires querying its return type. Use a named "
-                  "function object or a __host__ __device__ lambda instead.");
-  #endif
+#if defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) && \
+   !defined(__CUDA_ARCH__)
+  static_assert(!__nv_is_extended_device_lambda_closure_type(_Fp),
+                "Attempt to use an extended __device__ lambda in a context "
+                "that requires querying its return type in host code. Use a "
+                "named function object, a __host__ __device__ lambda, or "
+                "cuda::proclaim_return_type instead.");
+#endif
 };
 
 // result_of


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/libcudacxx/issues/277). The implementation of `result_of` and `invoke_result` was complimented with a static assert omitted in device code or compilers different than nvcc. In order not to force users to rewrite device lambdas as function objects, `cuda::proclaim_return_type` was added. Since the main use case for `cuda::proclaim_return_type` is device lambdas (which type is unknown in any way) I decided to hide the actual wrapper type in detailed namespace. 

Questions:
1. `docs/serve` failed to start locally without adding `gem "webrick"` dependency. I'm not sure if this has to be merged.
2. I've just learned about lit and I'm not sure if there's a way to check that the fail test emits text in static asserts. Please advise me on this matter if there's a portable way to do so. 