### PR TITLE
Remove usage of find_path to locate cuda/std/detail/__config

### DIFF
--- a/lib/cmake/libcudacxx/libcudacxx-header-search.cmake
+++ b/lib/cmake/libcudacxx/libcudacxx-header-search.cmake
@@ -1,8 +1,6 @@
 # Parse version information from version header:
-unset(_libcudacxx_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
-find_path(_libcudacxx_VERSION_INCLUDE_DIR cuda/std/detail/__config
-  NO_DEFAULT_PATH # Only search explicit paths below:
-  PATHS
-    "${CMAKE_CURRENT_LIST_DIR}/../../../include" # Source tree
-)
-set_property(CACHE _libcudacxx_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
+set(_libcudacxx_VERSION_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../include")
+if(EXISTS "${_libcudacxx_VERSION_INCLUDE_DIR}/cuda/std/detail/__config")
+  set(_libcudacxx_VERSION_INCLUDE_DIR "${_libcudacxx_VERSION_INCLUDE_DIR}" CACHE FILEPATH "" FORCE) # Clear old result
+  set_property(CACHE _libcudacxx_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
+endif()


### PR DESCRIPTION
When a consumer of libcudacxx uses the CMake `FIND_ROOT_PATH_MODE_INCLUDE` option it will cause all find_path searches to only occur under the find root path. Since this normally doesn't include the source files, it means that libcudacxx-header-search.cmake will fail to find the cuda/std/detail/__config file.

This issue was found when using conda-build on a project that includes libcudacxx, since conda-build sets up a cross compilation enviornment including a find root path.