### PR TITLE
Fix failures in several tests unsupportable by NVRTC.

### DIFF
--- a/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
+++ b/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
@@ -12,7 +12,7 @@
 
 #include <cuda/functional>
 
-#include <assert.h>
+#include <cuda/std/cassert>
 
 template <class T, class Fn, class... As>
 __host__ __device__
@@ -39,11 +39,13 @@ struct hd_callable
   __host__ __device__ int operator()() const&& { return 42; }
 };
 
+#if !defined(__CUDACC_RTC__)
 struct h_callable
 {
   __host__ int operator()() const& { return 42; }
   __host__ int operator()() const&& { return 42; }
 };
+#endif
 
 struct d_callable
 {
@@ -67,15 +69,17 @@ int main(int argc, char ** argv)
         [vp] __VA_ARGS__ () -> int& { return *vp; }, v);                       \
   }
 
+#if !defined(__CUDACC_RTC__)
   TEST_SPECIFIER(__device__)
   TEST_SPECIFIER(__host__ __device__)
+#endif
   TEST_SPECIFIER()
 #undef TEST_SPECIFIER
-  
-  test_proclaim_return_type<int>(hd_callable{}, 42);                                   
-  test_proclaim_return_type<int>(d_callable{}, 42);                                   
+
+  test_proclaim_return_type<int>(hd_callable{}, 42);
+  test_proclaim_return_type<int>(d_callable{}, 42);
 #else
-  test_proclaim_return_type<int>(h_callable{}, 42);                                   
+  test_proclaim_return_type<int>(h_callable{}, 42);
 #endif
 
   return 0;

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/non_arithmetic.fail.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/non_arithmetic.fail.cpp
@@ -8,6 +8,7 @@
 //
 // UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
 // UNSUPPORTED: windows && pre-sm-70
+// UNSUPPORTED: nvrtc
 
 // <cuda/std/atomic>
 

--- a/.upstream-tests/test/std/utilities/function.objects/comparisons/constexpr_init.pass.cpp
+++ b/.upstream-tests/test/std/utilities/function.objects/comparisons/constexpr_init.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++98, c++03, c++11
 
-// XFAIL: gcc-7
+// XFAIL: gcc-7 && !nvrtc
 // GCC 5: Fails for C++11, passes for C++14.
 // GCC 6: Fails for C++11, passes for C++14.
 // GCC 7: Fails for C++11, fails for C++14.

--- a/.upstream-tests/test/std/utilities/meta/meta.rel/is_nothrow_convertible.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.rel/is_nothrow_convertible.pass.cpp
@@ -17,13 +17,13 @@
 struct A {};
 struct B {
 public:
-    operator A() { return a; } A a;
+    __host__ __device__ operator A() { return a; } A a;
 };
 
 class C { };
 class D {
 public:
-    operator C() noexcept { return c; } C c;
+    __host__ __device__ operator C() noexcept { return c; } C c;
 };
 
 int main(int, char**) {

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/is_bounded_array.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/is_bounded_array.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // type_traits
 

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/is_unbounded_array.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.comp/is_unbounded_array.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // type_traits
 
@@ -65,7 +65,7 @@ int main(int, char**)
     test_array<Abstract,       false>();
     test_array<Enum,           false>();
     test_array<FunctionPtr,    false>();
-    
+
 //  Array types
     test_array<array,             false>();
     test_array<incomplete_array,  true>();

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // UNSUPPORTED: clang-3, clang-4, clang-5, apple-clang, gcc-5, gcc-6, msvc-19
 
 // type_traits

--- a/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_copyable_volatile.pass.cpp
+++ b/.upstream-tests/test/std/utilities/meta/meta.unary/meta.unary.prop/is_trivially_copyable_volatile.pass.cpp
@@ -28,6 +28,10 @@
 // detection should be changed to not report `nvcc` for NVRTC, but that's a
 // topic for another day.)
 
+// Because nvrtc inherits flags from the host compilers, gcc-7 expects failure while NVRTC builds pass.
+// Mark unsupported because the matrix of all {compiler && !nvrtc} is insane
+// UNSUPPORTED: nvrtc
+
 // If we're just building the test and not executing it, it should pass.
 // UNSUPPORTED: no_execute
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/decrement.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/decrement.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/increment.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/increment.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.day/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class day;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.last/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.last/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/day.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/day.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>
@@ -27,7 +27,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 #include <iostream>
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.md/types.pass.cpp
@@ -12,7 +12,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mdlast/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 
@@ -13,7 +13,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/decrement.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/decrement.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/increment.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/increment.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/plus_minus_equal.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.members/plus_minus_equal.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/literals.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/literals.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.month/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/weekday_indexed.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/weekday_indexed.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>
@@ -19,7 +19,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 #include <iostream>
 
 #include "test_macros.h"

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwd/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/weekday_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/weekday_last.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>
@@ -20,7 +20,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 #include <iostream>
 
 #include "test_macros.h"

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.mwdlast/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 
@@ -13,7 +13,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_day.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_day.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_day_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_day_last.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_day_last;
@@ -33,11 +33,6 @@
 //     constexpr auto mdl = February/last; // mdl is the last day of February of an as yet unspecified year
 //     static_assert(mdl.month() == February);
 // --end example]
-
-
-
-
-
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_weekday.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_weekday.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_weekday_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/month_weekday_last.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_day.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_day.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_day_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_day_last.pass.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
+
 // <chrono>
 // class year_month_day_last;
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_weekday.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_weekday.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_weekday_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.operators/year_month_weekday_last.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_indexed;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/index.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/index.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_indexed;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_indexed;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/weekday.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/weekday.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_indexed;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_indexed;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>
@@ -22,7 +22,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdidx/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_indexed;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/weekday.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/weekday.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>
@@ -19,7 +19,6 @@
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 #include <iostream>
 
 #include "test_macros.h"

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.wdlast/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday_last;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/c_encoding.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/c_encoding.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.local_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;
@@ -14,12 +14,12 @@
 //
 //  Effects:  Constructs an object of type weekday by computing what day
 //              of the week  corresponds to the local_days dp, and representing
-//              that day of the week in wd_ 
+//              that day of the week in wd_
 //
 //  Remarks: For any value ymd of type year_month_day for which ymd.ok() is true,
 //                ymd == year_month_day{sys_days{ymd}} is true.
-// 
-// [Example: 
+//
+// [Example:
 //  If dp represents 1970-01-01, the constructed weekday represents Thursday by storing 4 in wd_.
 // —end example]
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.sys_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;
@@ -14,12 +14,12 @@
 //
 //  Effects:  Constructs an object of type weekday by computing what day
 //              of the week  corresponds to the sys_days dp, and representing
-//              that day of the week in wd_ 
+//              that day of the week in wd_
 //
 //  Remarks: For any value ymd of type year_month_day for which ymd.ok() is true,
 //                ymd == year_month_day{sys_days{ymd}} is true.
-// 
-// [Example: 
+//
+// [Example:
 //  If dp represents 1970-01-01, the constructed weekday represents Thursday by storing 4 in wd_.
 // —end example]
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/decrement.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/decrement.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/increment.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/increment.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/iso_encoding.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/iso_encoding.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/operator_index.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/operator_index.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/plus_minus_equal.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/plus_minus_equal.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/literals.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/literals.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11, nvrtc
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.weekday/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class weekday;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/decrement.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/decrement.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/increment.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/increment.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/is_leap.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/is_leap.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus_equal.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus_equal.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.fail.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.fail.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11, c++14, c++17
+// UNSUPPORTED: c++98, c++03, c++11, c++14, c++17, nvrtc
 // UNSUPPORTED: clang-5, clang-6
 // UNSUPPORTED: apple-clang-6, apple-clang-7, apple-clang-8, apple-clang-9, apple-clang-10
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.year/types.pass.cpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year;
 
 #include <cuda/std/chrono>
 #include <cuda/std/type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ym/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.year_month_day_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.year_month_day_last.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/day.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/day.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymd/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/day.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/day.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month_day_last.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month_day_last.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/op_local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/op_local_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;
@@ -33,7 +33,7 @@ int main(int, char**)
     { // Last day in Jan 1970 was the 31st
     constexpr year_month_day_last ymdl{year{1970}, month_day_last{cuda::std::chrono::January}};
     constexpr local_days sd{ymdl};
-    
+
     static_assert(sd.time_since_epoch() == days{30}, "");
     }
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: gcc-4.8, gcc-5, gcc-6
 // gcc before gcc-7 fails with an internal compiler error
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: gcc-4.8, gcc-5, gcc-6
 // gcc before gcc-7 fails with an internal compiler error
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/index.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/index.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: gcc-4.8, gcc-5, gcc-6
 // gcc before gcc-7 fails with an internal compiler error
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: gcc-4.8, gcc-5, gcc-6
 // gcc before gcc-7 fails with an internal compiler error
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday_indexed.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday_indexed.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwd/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ctor.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ctor.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ok.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ok.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/op_local_days.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/op_local_days.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_day_last;
@@ -33,7 +33,7 @@ int main(int, char**)
     { // Last day in Jan 1970 was the 31st
     constexpr year_month_day_last ymdl{year{1970}, month_day_last{cuda::std::chrono::January}};
     constexpr local_days sd{ymdl};
-    
+
     static_assert(sd.time_since_epoch() == days{30}, "");
     }
 

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_month.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_month.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/weekday.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/weekday.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/year.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/year.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/comparisons.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/comparisons.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/minus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/minus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/plus.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/plus.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last;

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11, c++14, c++17
+// UNSUPPORTED: c++98, c++03, c++11, c++14, c++17, nvrtc
 // XFAIL: *
 
 // <chrono>

--- a/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/types.pass.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.cal/time.cal.ymwdlast/types.pass.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 
 // <chrono>
 // class year_month_weekday_last_last;

--- a/.upstream-tests/test/std/utilities/time/time.hms/hhmmss.fail.cpp
+++ b/.upstream-tests/test/std/utilities/time/time.hms/hhmmss.fail.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: c++98, c++03, c++11
+// UNSUPPORTED: c++98, c++03, c++11, nvrtc
 // UNSUPPORTED: apple-clang-9
 // <chrono>
 

--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/nothrow_cnstr.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.cnstr/nothrow_cnstr.pass.cpp
@@ -16,8 +16,8 @@
 // Internal compiler error in 14.24
 // XFAIL: msvc-19.20, msvc-19.21, msvc-19.22, msvc-19.23, msvc-19.24, msvc-19.25
 
-// XFAIL: gcc-8 && c++17
-// XFAIL: gcc-7 && c++17
+// XFAIL: gcc-8 && c++17 && !nvrtc
+// XFAIL: gcc-7 && c++17 && !nvrtc
 
 #include <cuda/std/tuple>
 #include <cuda/std/utility>


### PR DESCRIPTION
Mark most tests that require host standard library support as unsupported.

Fix an issue in CUDA tests where NVRTC complains about `--extend-lambda`.