### PR TITLE
Move the emission of atomic errors on unsupported platforms to <atomic>

### DIFF
--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -1556,7 +1556,7 @@ extern "C" _LIBCUDACXX_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 #  elif defined(_LIBCUDACXX_WIN32API)
 #    define _LIBCUDACXX_HAS_THREAD_API_WIN32
 #  else
-#    error "No thread API"
+#    define _LIBCUDACXX_UNSUPPORTED_THREAD_API
 #  endif // _LIBCUDACXX_HAS_THREAD_API
 #endif // _LIBCUDACXX_HAS_NO_THREADS
 

--- a/include/cuda/std/detail/libcxx/include/atomic
+++ b/include/cuda/std/detail/libcxx/include/atomic
@@ -568,6 +568,9 @@ void atomic_signal_fence(memory_order m) noexcept;
 #ifdef _LIBCUDACXX_HAS_NO_ATOMIC_HEADER
 # error <atomic> is not implemented
 #endif
+#ifdef _LIBCUDACXX_UNSUPPORTED_THREAD_API
+# error "<atomic> is not supported on this system"
+#endif
 #ifdef kill_dependency
 # error C++ standard library is incompatible with <stdatomic.h>
 #endif


### PR DESCRIPTION
Moves `#error` for unsupported threading platforms to a header where it is relevant.

This allows `<type_traits>` or other headers to actually have a chance at compiling.