### PR TITLE
<atomics> Remove defaulted copy constructor from __cxx_atomic_lock_impl

### DIFF
--- a/.upstream-tests/test/std/atomics/atomics.types.generic/non_trivial.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/non_trivial.pass.cpp
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+
+// NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
+// clang versions. It was fixed right before the llvm 3.5 release. See PR18097.
+// XFAIL: apple-clang-6.0, clang-3.4, clang-3.3
+
+// <cuda/std/atomic>
+
+// template <class T>
+// struct atomic
+// {
+//     bool is_lock_free() const volatile noexcept;
+//     bool is_lock_free() const noexcept;
+//     void store(T desr, memory_order m = memory_order_seq_cst) volatile noexcept;
+//     void store(T desr, memory_order m = memory_order_seq_cst) noexcept;
+//     T load(memory_order m = memory_order_seq_cst) const volatile noexcept;
+//     T load(memory_order m = memory_order_seq_cst) const noexcept;
+//     operator T() const volatile noexcept;
+//     operator T() const noexcept;
+//     T exchange(T desr, memory_order m = memory_order_seq_cst) volatile noexcept;
+//     T exchange(T desr, memory_order m = memory_order_seq_cst) noexcept;
+//     bool compare_exchange_weak(T& expc, T desr,
+//                                memory_order s, memory_order f) volatile noexcept;
+//     bool compare_exchange_weak(T& expc, T desr, memory_order s, memory_order f) noexcept;
+//     bool compare_exchange_strong(T& expc, T desr,
+//                                  memory_order s, memory_order f) volatile noexcept;
+//     bool compare_exchange_strong(T& expc, T desr,
+//                                  memory_order s, memory_order f) noexcept;
+//     bool compare_exchange_weak(T& expc, T desr,
+//                                memory_order m = memory_order_seq_cst) volatile noexcept;
+//     bool compare_exchange_weak(T& expc, T desr,
+//                                memory_order m = memory_order_seq_cst) noexcept;
+//     bool compare_exchange_strong(T& expc, T desr,
+//                                 memory_order m = memory_order_seq_cst) volatile noexcept;
+//     bool compare_exchange_strong(T& expc, T desr,
+//                                  memory_order m = memory_order_seq_cst) noexcept;
+//
+//     atomic() noexcept = default;
+//     constexpr atomic(T desr) noexcept;
+//     atomic(const atomic&) = delete;
+//     atomic& operator=(const atomic&) = delete;
+//     atomic& operator=(const atomic&) volatile = delete;
+//     T operator=(T) volatile noexcept;
+//     T operator=(T) noexcept;
+// };
+
+#include <cuda/atomic>
+#include <cuda/std/atomic>
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include "test_macros.h"
+
+struct aggregate {
+    double a;
+    double b;
+};
+
+template <class T>
+__host__ __device__
+void test() {
+    cuda::atomic<T> a({42, 1337});
+    cuda::std::atomic<T> b({42, 1337});
+}
+
+int main(int, char**)
+{
+  test<double2>();
+  test<cuda::std::pair<double, double>>();
+  test<cuda::std::tuple<double, double>>();
+  test<aggregate>();
+
+  return 0;
+}

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/non_trivial.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/non_trivial.pass.cpp
@@ -58,6 +58,10 @@
 
 #include "test_macros.h"
 
+template <typename T>
+__host__ __device__
+constexpr bool unused(T &&) {return true;}
+
 struct aggregate {
     double a;
     double b;
@@ -68,6 +72,8 @@ __host__ __device__
 void test() {
     cuda::atomic<T> a({42, 1337});
     cuda::std::atomic<T> b({42, 1337});
+    unused(a);
+    unused(b);
 }
 
 int main(int, char**)

--- a/.upstream-tests/test/std/atomics/atomics.types.generic/non_trivial.pass.cpp
+++ b/.upstream-tests/test/std/atomics/atomics.types.generic/non_trivial.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// UNSUPPORTED: libcpp-has-no-threads, pre-sm-60
+// UNSUPPORTED: windows && pre-sm-70
 
 // NOTE: atomic<> of a TriviallyCopyable class is wrongly rejected by older
 // clang versions. It was fixed right before the llvm 3.5 release. See PR18097.

--- a/include/cuda/std/detail/libcxx/include/atomic
+++ b/include/cuda/std/detail/libcxx/include/atomic
@@ -757,8 +757,6 @@ struct __cxx_atomic_lock_impl {
   __cxx_atomic_lock_impl(_Tp value) _NOEXCEPT
     : __a_value(value), __a_lock(0) {}
 
-  __cxx_atomic_lock_impl(const __cxx_atomic_lock_impl&) _NOEXCEPT = default;
-
   _Tp __a_value;
   mutable __cxx_atomic_base_impl<_LIBCUDACXX_ATOMIC_FLAG_TYPE, _Sco> __a_lock;
 


### PR DESCRIPTION
Defaulting the copy constructor inhibits the compiler defaulting the move constructor. Also it is not needed here at all.

Fixes: nvbug3785347