### PR TITLE
Use escape hook for removal of <ciso646>

### DIFF
--- a/.upstream-tests/test/support/msvc_stdlib_force_include.h
+++ b/.upstream-tests/test/support/msvc_stdlib_force_include.h
@@ -78,6 +78,7 @@ const AssertionDialogAvoider assertion_dialog_avoider{};
     #define _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS
 #endif // _LIBCXX_IN_DEVCRT
 
+#define _SILENCE_CXX20_CISO646_REMOVED_WARNING
 #include <ciso646>
 
 #if _HAS_CXX20


### PR DESCRIPTION
<ciso646> has been removed in C++20, which in the future might break the build against MSVC. 

Fortunately, there is an escape hatch that we can use to silence the deprecation warning and buy us some time until we settle on a better solution