### PR TITLE
Fix structured binding support

### DIFF
--- a/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_structured_bindings.pass.cpp
+++ b/.upstream-tests/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_size_structured_bindings.pass.cpp
@@ -20,8 +20,7 @@
 // UNSUPPORTED: msvc
 
 #include <cuda/std/tuple>
-// cuda::std::array not supported
-//#include <cuda/std/array>
+#include <cuda/std/array>
 #include <cuda/std/type_traits>
 #include <cuda/std/cassert>
 
@@ -48,8 +47,6 @@ __host__ __device__ void test_decomp_user_type() {
 
 __host__ __device__ void test_decomp_tuple() {
   typedef cuda::std::tuple<int> T;
-  // Possible compiler bug?
-  /*
   {
     T s{99};
     auto [m1] = s;
@@ -64,7 +61,6 @@ __host__ __device__ void test_decomp_tuple() {
     assert(m1 == 99);
     assert(&r1 == &cuda::std::get<0>(s));
   }
-  */
 }
 
 __host__ __device__ void test_decomp_pair() {
@@ -89,8 +85,6 @@ __host__ __device__ void test_decomp_pair() {
   }
 }
 
-// cuda::std::array not supported
-/*
 __host__ __device__ void test_decomp_array() {
   typedef cuda::std::array<int, 3> T;
   {
@@ -116,7 +110,6 @@ __host__ __device__ void test_decomp_array() {
     assert(&r3 == &cuda::std::get<2>(s));
   }
 }
-*/
 
 struct Test {
   int x;
@@ -152,8 +145,7 @@ int main(int, char**) {
   test_decomp_user_type();
   test_decomp_tuple();
   test_decomp_pair();
-  // cuda::std::array not supported
-  //test_decomp_array();
+  test_decomp_array();
   test_before_tuple_size_specialization();
   test_after_tuple_size_specialization();
 

--- a/include/cuda/std/detail/libcxx/include/__tuple
+++ b/include/cuda/std/detail/libcxx/include/__tuple
@@ -558,7 +558,27 @@ struct __sfinae_assign_base<false, true> {
 };
 #endif // _LIBCUDACXX_STD_VER > 14
 
+template <size_t...>
+using _Ivoid_t = void;
+
 _LIBCUDACXX_END_NAMESPACE_STD
+
+// This is a workaround for the fact that structured bindings require that the specializations of
+// `tuple_size` and `tuple_element` reside in namespace std (https://eel.is/c++draft/dcl.struct.bind#4).
+// See https://github.com/NVIDIA/libcudacxx/issues/316 for a short discussion
+#if _LIBCUDACXX_STD_VER > 14
+namespace std {
+    template <class... _Tp>
+    struct tuple_size<_CUDA_VSTD::tuple<_Tp...>> 
+      : integral_constant<size_t, _CUDA_VSTD::tuple_size<_CUDA_VSTD::tuple<_Tp...>>::value>
+    {};
+
+    template<size_t _Ip, class... _Tp>
+    struct tuple_element<_Ip, _CUDA_VSTD::tuple<_Tp...>> {
+      using type = typename _CUDA_VSTD::tuple_element<_Ip, _CUDA_VSTD::tuple<_Tp...>>::type;
+    };
+}
+#endif // _LIBCUDACXX_STD_VER > 14
 
 #ifndef __cuda_std__
 #include <__pragma_pop>

--- a/include/cuda/std/detail/libcxx/include/__tuple
+++ b/include/cuda/std/detail/libcxx/include/__tuple
@@ -570,13 +570,13 @@ _LIBCUDACXX_END_NAMESPACE_STD
 namespace std {
     template <class... _Tp>
     struct tuple_size<_CUDA_VSTD::tuple<_Tp...>> 
-      : integral_constant<size_t, _CUDA_VSTD::tuple_size<_CUDA_VSTD::tuple<_Tp...>>::value>
+      : _CUDA_VSTD::tuple_size<_CUDA_VSTD::tuple<_Tp...>> 
     {};
 
     template<size_t _Ip, class... _Tp>
-    struct tuple_element<_Ip, _CUDA_VSTD::tuple<_Tp...>> {
-      using type = typename _CUDA_VSTD::tuple_element<_Ip, _CUDA_VSTD::tuple<_Tp...>>::type;
-    };
+    struct tuple_element<_Ip, _CUDA_VSTD::tuple<_Tp...>> 
+      : _CUDA_VSTD::tuple_element<_Ip, _CUDA_VSTD::tuple<_Tp...>>
+    {};
 }
 #endif // _LIBCUDACXX_STD_VER > 14
 

--- a/include/cuda/std/detail/libcxx/include/array
+++ b/include/cuda/std/detail/libcxx/include/array
@@ -483,4 +483,21 @@ get(const array<_Tp, _Size>&& __a) _NOEXCEPT
 
 _LIBCUDACXX_END_NAMESPACE_STD
 
+// This is a workaround for the fact that structured bindings require that the specializations of
+// `tuple_size` and `tuple_element` reside in namespace std (https://eel.is/c++draft/dcl.struct.bind#4).
+// See https://github.com/NVIDIA/libcudacxx/issues/316 for a short discussion
+#if _LIBCUDACXX_STD_VER > 14
+namespace std {
+    template <class _Tp, size_t _Size>
+    struct tuple_size<_CUDA_VSTD::array<_Tp, _Size>> 
+      : integral_constant<size_t, _CUDA_VSTD::tuple_size<_CUDA_VSTD::array<_Tp, _Size>>::value>
+    {};
+
+    template<size_t _Ip, class _Tp, size_t _Size>
+    struct tuple_element<_Ip, _CUDA_VSTD::array<_Tp, _Size>> {
+      using type = typename _CUDA_VSTD::tuple_element<_Ip, _CUDA_VSTD::array<_Tp, _Size>>::type;
+    };
+}
+#endif // _LIBCUDACXX_STD_VER > 14
+
 #endif  // _LIBCUDACXX_ARRAY

--- a/include/cuda/std/detail/libcxx/include/array
+++ b/include/cuda/std/detail/libcxx/include/array
@@ -490,13 +490,13 @@ _LIBCUDACXX_END_NAMESPACE_STD
 namespace std {
     template <class _Tp, size_t _Size>
     struct tuple_size<_CUDA_VSTD::array<_Tp, _Size>> 
-      : integral_constant<size_t, _CUDA_VSTD::tuple_size<_CUDA_VSTD::array<_Tp, _Size>>::value>
+      : _CUDA_VSTD::tuple_size<_CUDA_VSTD::array<_Tp, _Size>>
     {};
 
     template<size_t _Ip, class _Tp, size_t _Size>
-    struct tuple_element<_Ip, _CUDA_VSTD::array<_Tp, _Size>> {
-      using type = typename _CUDA_VSTD::tuple_element<_Ip, _CUDA_VSTD::array<_Tp, _Size>>::type;
-    };
+    struct tuple_element<_Ip, _CUDA_VSTD::array<_Tp, _Size>> 
+      : _CUDA_VSTD::tuple_element<_Ip, _CUDA_VSTD::array<_Tp, _Size>>
+    {};
 }
 #endif // _LIBCUDACXX_STD_VER > 14
 


### PR DESCRIPTION
Currently structured bindings for `cuda::std::tuple` and `cuda::std::array` were broken.

The reason for that is that the standard requires, that the specializations of `tuple_size` and `tuple_element` reside in namespace std. whereas our specializations resided in namespace `cuda::std`

Work around that by pulling those specializations into namespace std too.

Fixes CUDA Tuple Structured Binding Declaration Broken #316