### PR TITLE
Correct issues with CMake install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ else()
   set(LIBCUDACXX_TOPLEVEL_PROJECT OFF)
 endif()
 
+set(PACKAGE_NAME libcudacxx)
+set(PACKAGE_VERSION 11.0)
+set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+project(libcudacxx NONE)
+
 include(cmake/libcudacxxInstallRules.cmake)
 
 if (NOT LIBCUDACXX_TOPLEVEL_PROJECT)
@@ -29,11 +34,6 @@ if (libcudacxx_ENABLE_CMAKE_TESTS)
   add_subdirectory(cmake/test/)
   return()
 endif()
-
-set(PACKAGE_NAME libcudacxx)
-set(PACKAGE_VERSION 11.0)
-set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
-project(libcudacxx NONE)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(LLVM_PATH "${CMAKE_SOURCE_DIR}" CACHE STRING "" FORCE)

--- a/cmake/libcudacxxInstallRules.cmake
+++ b/cmake/libcudacxxInstallRules.cmake
@@ -20,7 +20,7 @@ install(DIRECTORY "${libcudacxx_SOURCE_DIR}/include/nv"
 # Libcudacxx cmake package
 install(DIRECTORY "${libcudacxx_SOURCE_DIR}/lib/cmake/libcudacxx"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake"
-  PATTERN libcudacxx-header-search EXCLUDE
+  PATTERN *.cmake.in EXCLUDE
 )
 
 # Need to configure a file to store CMAKE_INSTALL_INCLUDEDIR

--- a/cmake/libcudacxxInstallRules.cmake
+++ b/cmake/libcudacxxInstallRules.cmake
@@ -12,9 +12,11 @@ include(GNUInstallDirs)
 # Libcudacxx headers
 install(DIRECTORY "${libcudacxx_SOURCE_DIR}/include/cuda"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  PATTERN CMakeLists.txt EXCLUDE
 )
 install(DIRECTORY "${libcudacxx_SOURCE_DIR}/include/nv"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  PATTERN CMakeLists.txt EXCLUDE
 )
 
 # Libcudacxx cmake package

--- a/cmake/libcudacxxInstallRules.cmake
+++ b/cmake/libcudacxxInstallRules.cmake
@@ -1,5 +1,5 @@
 option(libcudacxx_ENABLE_INSTALL_RULES
-  "Enable installation of libcudacxx" ${libcudacxx_TOPLEVEL_PROJECT}
+  "Enable installation of libcudacxx" ${LIBCUDACXX_TOPLEVEL_PROJECT}
 )
 
 if (NOT libcudacxx_ENABLE_INSTALL_RULES)


### PR DESCRIPTION
This corrects three issues found by `rapids-cmake` and others when trying to install libcudacxx.

1. The `install` commands need to come after `project`. The `install` commands aren't allowed when in CMake scripting mode which is the mode you are in before the first call to `project()`
2. The `install(DIRECTORY PATTERN)` matches the end of a file name, not the front so we need to use `*.cmake.in` to not
install the template files
3. We incorrectly used `libcudacxx_TOPLEVEL_PROJECT` instead of `LIBCUDACXX_TOPLEVEL_PROJECT` so we never defaulted to have install rules enabled when building libcudacxx itself.
4. Don't install any CMakeLists.txt files that are inside `include/cuda' or `include/nv'