### PR TITLE
Update thread scope for synchronization domains

### DIFF
--- a/docs/extended_api/memory_model.md
+++ b/docs/extended_api/memory_model.md
@@ -36,7 +36,7 @@ enum thread_scope {
 
 Each program thread is related to each other program thread by one or more thread scope relations:
 - Each thread in the system is related to each other thread in the system by the *system* thread scope: `thread_scope_system`.
-- Each GPU thread is related to each other GPU thread in the same CUDA device by the *device* thread scope: `thread_scope_device`.
+- Each GPU thread is related to each other GPU thread in the same CUDA device and within the same [memory synchronization domain](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#memory-synchronization-domains) by the *device* thread scope: `thread_scope_device`.
 - Each GPU thread is related to each other GPU thread in the same CUDA thread block by the *block* thread scope: `thread_scope_block`.
 - Each thread is related to itself by the `thread` thread scope: `thread_scope_thread`.
 


### PR DESCRIPTION
CUDA 12.0 introduced the "Memory Synchronization Domains" feature:
https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#memory-synchronization-domains

As described in that CUDA documentation, this feature changes the definition of `thread_scope_device`.

Update libcu++ to match that definition update.