### PR TITLE
Add support for testing on ARM64

### DIFF
--- a/environments/linux/docker/.env
+++ b/environments/linux/docker/.env
@@ -1,0 +1,2 @@
+### Set default arch
+DEFAULT_ARCH=linux/amd64

--- a/environments/linux/docker/compose.yml
+++ b/environments/linux/docker/compose.yml
@@ -4,6 +4,7 @@ services:
     image: "local/cccl-ubuntu22.04"
     tty: true
     profiles: ["base"]
+    platform: $DEFAULT_ARCH
     build:
       cache_from:
         - "local/cccl-ubuntu22.04:latest"

--- a/environments/linux/docker/ubuntu.base.Dockerfile
+++ b/environments/linux/docker/ubuntu.base.Dockerfile
@@ -10,7 +10,6 @@ FROM ${ROOT_IMAGE} AS devenv
 ARG COMPILERS="gcc clang"
 
 ARG CMAKE_VER=3.23.1
-ARG CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-x86_64.sh
 
 ARG UBUNTU_TOOL_DEB_REPO=https://ppa.launchpadcontent.net/ubuntu-toolchain-r/ppa/ubuntu
 ARG UBUNTU_TOOL_FINGER=60C317803A41BA51845E371A1E9377A2BA9EF27F
@@ -30,7 +29,7 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 SHELL ["/usr/bin/env", "bash", "-c"]
 
 ADD ${LLVM_INSTALLER} /tmp/llvm.sh
-ADD ${CMAKE_URL} /tmp/cmake.sh
+
 
 # Install baseline development tools
 RUN function comment() { :; }; \
@@ -49,6 +48,7 @@ RUN function comment() { :; }; \
     if [ "${USE_LLVM_INSTALLER}" -eq "1" ]; then echo "\n" | bash /tmp/llvm.sh all; fi; \
     ${APT_GET} install gcc g++ ${COMPILERS}; \
     comment "Install CMake"; \
+    wget -O /tmp/cmake.sh "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-$(arch).sh"; \
     sh /tmp/cmake.sh --skip-license --prefix=/usr; \
     comment "Install Python utils"; \
     update-alternatives --quiet --install /usr/bin/python python $(which python3) 3; \


### PR DESCRIPTION
Hacky, but by setting the environment up to override the default setting we can now test on ARM.

```
DEFAULT_ARCH=linux/arm64
docker compose --profile gcc-12 -f "environments\linux\docker\compose.yml" build
docker run -it --gpus all libcudacxx/gcc-12
```
Result:
```
PS C:\Users\Wes\Documents\workspace\libcudacxx> docker run -it --gpus all libcudacxx/gcc-12
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested

root@477ca5b56973:/#
```

Obviously if you are running on x86, you can't passthrough a GPU to the guest image. That's fine for `NoopExecutor()` testing, but this lets us begin testing on ARM machines internally.