### PR TITLE
Use pragma to disable execution checks in cuda::proclaim_return_type.

### DIFF
--- a/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
+++ b/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
@@ -15,6 +15,8 @@
 
 #include <cuda/std/cassert>
 
+#include "test_macros.h"
+
 template <class T, class Fn, class... As>
 __host__ __device__
 void test_proclaim_return_type(Fn&& fn, T expected, As... as)
@@ -44,7 +46,7 @@ struct hd_callable
   __host__ __device__ int operator()() const&& { return 42; }
 };
 
-#if !defined(__CUDACC_RTC__)
+#if !defined(TEST_COMPILER_NVRTC)
 struct h_callable
 {
   __host__ int operator()() const& { return 42; }
@@ -60,32 +62,42 @@ struct d_callable
 
 int main(int argc, char ** argv)
 {
-#ifdef __CUDA_ARCH__
-#define TEST_SPECIFIER(...)                                                    \
-  {                                                                            \
-    test_proclaim_return_type<double>([] __VA_ARGS__ () { return 42.0; },      \
-                                      42.0);                                   \
-    test_proclaim_return_type<int>([] __VA_ARGS__ (int v) { return v * 2; },   \
-                                   42, 21);                                    \
-                                                                               \
-    int v = 42;                                                                \
-    int* vp = &v;                                                              \
-    test_proclaim_return_type<int&>(                                           \
-        [vp] __VA_ARGS__ () -> int& { return *vp; }, v);                       \
-  }
+  int v = 42;
+  int* vp = &v;
 
-#if !defined(__CUDACC_RTC__)
-  TEST_SPECIFIER(__device__)
-  TEST_SPECIFIER(__host__ __device__)
-#endif
-  TEST_SPECIFIER()
-#undef TEST_SPECIFIER
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
+    test_proclaim_return_type<int>(hd_callable{}, 42);
+    test_proclaim_return_type<int>(d_callable{}, 42);
+  ),(
+    test_proclaim_return_type<double>([]   { return 42.0; }, 42.0);
+    test_proclaim_return_type<int>   ([]   (const int v) { return v * 2; }, 42, 21);
+    test_proclaim_return_type<int&>  ([vp] () -> int& { return *vp; }, v);
 
-  test_proclaim_return_type<int>(hd_callable{}, 42);
-  test_proclaim_return_type<int>(d_callable{}, 42);
-#else
-  test_proclaim_return_type<int>(h_callable{}, 42);
-#endif
+    test_proclaim_return_type<int>(hd_callable{}, 42);
+  ))
+
+  // execution space annotations on lambda require --extended-lambda flag with nvrtc
+#if !defined(TEST_COMPILER_NVRTC)
+  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
+    test_proclaim_return_type<double>([]   __device__ { return 42.0; }, 42.0);
+    test_proclaim_return_type<int>   ([]   __device__ (const int v) { return v * 2; }, 42, 21);
+    test_proclaim_return_type<int&>  ([vp] __device__ () -> int& { return *vp; }, v);
+
+    test_proclaim_return_type<double>([]   __host__ __device__ { return 42.0; }, 42.0);
+    test_proclaim_return_type<int>   ([]   __host__ __device__ (const int v) { return v * 2; }, 42, 21);
+    test_proclaim_return_type<int&>  ([vp] __host__ __device__ () -> int& { return *vp; }, v);
+  ),(
+    test_proclaim_return_type<int>(h_callable{}, 42);
+  ))
+
+  // Ensure that we can always declare functions even on host
+  auto f = cuda::proclaim_return_type<bool>([] __device__() { return false; });
+  auto g = cuda::proclaim_return_type<bool>([f] __device__() { return f(); });
+
+  unused(f);
+  unused(g);
+#endif // !TEST_COMPILER_NVRTC
+
 
   return 0;
 }

--- a/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
+++ b/.upstream-tests/test/cuda/proclaim_return_type.pass.cpp
@@ -65,29 +65,28 @@ int main(int argc, char ** argv)
   int v = 42;
   int* vp = &v;
 
+  test_proclaim_return_type<int>(hd_callable{}, 42);
+  test_proclaim_return_type<double>([]   { return 42.0; }, 42.0);
+  test_proclaim_return_type<int>   ([]   (const int v) { return v * 2; }, 42, 21);
+  test_proclaim_return_type<int&>  ([vp] () -> int& { return *vp; }, v);
+
   NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
-    test_proclaim_return_type<int>(hd_callable{}, 42);
     test_proclaim_return_type<int>(d_callable{}, 42);
   ),(
-    test_proclaim_return_type<double>([]   { return 42.0; }, 42.0);
-    test_proclaim_return_type<int>   ([]   (const int v) { return v * 2; }, 42, 21);
-    test_proclaim_return_type<int&>  ([vp] () -> int& { return *vp; }, v);
-
-    test_proclaim_return_type<int>(hd_callable{}, 42);
+    test_proclaim_return_type<int>(h_callable{}, 42);
   ))
+
 
   // execution space annotations on lambda require --extended-lambda flag with nvrtc
 #if !defined(TEST_COMPILER_NVRTC)
-  NV_IF_ELSE_TARGET(NV_IS_DEVICE, (
+  NV_IF_TARGET(NV_IS_DEVICE, (
     test_proclaim_return_type<double>([]   __device__ { return 42.0; }, 42.0);
     test_proclaim_return_type<int>   ([]   __device__ (const int v) { return v * 2; }, 42, 21);
     test_proclaim_return_type<int&>  ([vp] __device__ () -> int& { return *vp; }, v);
 
-    test_proclaim_return_type<double>([]   __host__ __device__ { return 42.0; }, 42.0);
-    test_proclaim_return_type<int>   ([]   __host__ __device__ (const int v) { return v * 2; }, 42, 21);
+    test_proclaim_return_type<double>([] __host__ __device__ { return 42.0; }, 42.0);
+    test_proclaim_return_type<int>   ([] __host__ __device__ (const int v) { return v * 2; }, 42, 21);
     test_proclaim_return_type<int&>  ([vp] __host__ __device__ () -> int& { return *vp; }, v);
-  ),(
-    test_proclaim_return_type<int>(h_callable{}, 42);
   ))
 
   // Ensure that we can always declare functions even on host

--- a/include/cuda/functional
+++ b/include/cuda/functional
@@ -71,23 +71,20 @@ class __return_type_wrapper {
  public:
   __return_type_wrapper() = delete;
 
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
-  __return_type_wrapper(__return_type_wrapper const&) = default;
-
   template <class _Fn,
             class = _CUDA_VSTD::__enable_if_t<_CUDA_VSTD::is_same<_CUDA_VSTD::__decay_t<_Fn>, _DecayFn>::value>>
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
   explicit __return_type_wrapper(_Fn &&__fn) noexcept
     : __fn_(_CUDA_VSTD::forward<_Fn>(__fn)) {}
 
   template <class... _As>
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
-  operator()(_As&&... __as) & noexcept {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+  _Ret operator()(_As&&... __as) & noexcept {
 #if !defined(__NVCC__) || defined(__CUDA_ARCH__)
     static_assert(
         _CUDA_VSTD::is_same<
             _Ret,
-            typename _CUDA_VSTD::__invoke_of<_DecayFn, _As...>::type
+            typename _CUDA_VSTD::__invoke_of<_DecayFn&, _As...>::type
           >::value,
         "Return type shall match the proclaimed one exactly");
 #endif
@@ -96,13 +93,13 @@ class __return_type_wrapper {
   }
 
   template <class... _As>
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
-  operator()(_As&&... __as) && noexcept {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+  _Ret operator()(_As&&... __as) && noexcept {
 #if !defined(__NVCC__) || defined(__CUDA_ARCH__)
     static_assert(
         _CUDA_VSTD::is_same<
             _Ret,
-            typename _CUDA_VSTD::__invoke_of<_DecayFn&&, _As...>::type
+            typename _CUDA_VSTD::__invoke_of<_DecayFn, _As...>::type
           >::value,
         "Return type shall match the proclaimed one exactly");
 #endif
@@ -112,13 +109,13 @@ class __return_type_wrapper {
   }
 
   template <class... _As>
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
-  operator()(_As&&... __as) const& noexcept {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+  _Ret operator()(_As&&... __as) const& noexcept {
 #if !defined(__NVCC__) || defined(__CUDA_ARCH__)
     static_assert(
         _CUDA_VSTD::is_same<
             _Ret,
-            typename _CUDA_VSTD::__invoke_of<_DecayFn, _As...>::type
+            typename _CUDA_VSTD::__invoke_of<const _DecayFn&, _As...>::type
           >::value,
         "Return type shall match the proclaimed one exactly");
 #endif
@@ -127,13 +124,13 @@ class __return_type_wrapper {
   }
 
   template <class... _As>
-  _LIBCUDACXX_CONSTEXPR_AFTER_CXX11 _LIBCUDACXX_INLINE_VISIBILITY _Ret
-  operator()(_As&&... __as) const&& noexcept {
+  _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX11
+  _Ret operator()(_As&&... __as) const&& noexcept {
 #if !defined(__NVCC__) || defined(__CUDA_ARCH__)
     static_assert(
         _CUDA_VSTD::is_same<
             _Ret,
-            typename _CUDA_VSTD::__invoke_of<_DecayFn&&, _As...>::type
+            typename _CUDA_VSTD::__invoke_of<const _DecayFn, _As...>::type
           >::value,
         "Return type shall match the proclaimed one exactly");
 #endif

--- a/include/cuda/memory_resource
+++ b/include/cuda/memory_resource
@@ -151,17 +151,13 @@ _LIBCUDACXX_CONCEPT __has_upstream_resource = _LIBCUDACXX_FRAGMENT(__has_upstrea
 _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__forward_property)
 template <class _Derived, class _Upstream>
 struct __fn {
-  #if defined(_LIBCUDACXX_COMPILER_NVCC)
-  #pragma nv_exec_check_disable
-  #endif
+  _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Property)
     (requires (!property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
   _LIBCUDACXX_INLINE_VISIBILITY friend constexpr void get_property(const _Derived&, _Property) noexcept {}
 
   // The indirection is needed, otherwise the compiler might believe that _Derived is an incomplete type
-  #if defined(_LIBCUDACXX_COMPILER_NVCC)
-  #pragma nv_exec_check_disable
-  #endif
+  _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Property, class _Derived2 = _Derived)
     (requires property_with_value<_Property> _LIBCUDACXX_AND has_property<_Upstream, _Property> _LIBCUDACXX_AND
               __has_upstream_resource<_Derived2, _Upstream>)
@@ -180,16 +176,12 @@ using forward_property = __forward_property::__fn<_Derived, _Upstream>;
 ///        We can always tell people to just derive from it to properly forward all properties
 _LIBCUDACXX_BEGIN_NAMESPACE_CPO(__get_property)
 struct __fn {
-  #if defined(_LIBCUDACXX_COMPILER_NVCC)
-  #pragma nv_exec_check_disable
-  #endif
+  _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Upstream, class _Property)
     (requires (!property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
   _LIBCUDACXX_INLINE_VISIBILITY constexpr void operator()(const _Upstream&, _Property) const noexcept {}
 
-  #if defined(_LIBCUDACXX_COMPILER_NVCC)
-  #pragma nv_exec_check_disable
-  #endif
+  _LIBCUDACXX_DISABLE_EXEC_CHECK
   _LIBCUDACXX_TEMPLATE(class _Upstream, class _Property)
     (requires (property_with_value<_Property>) _LIBCUDACXX_AND has_property<_Upstream, _Property>)
   _LIBCUDACXX_INLINE_VISIBILITY constexpr __property_value_t<_Property> operator()(

--- a/include/cuda/std/detail/libcxx/include/__config
+++ b/include/cuda/std/detail/libcxx/include/__config
@@ -2121,6 +2121,12 @@ extern "C" _LIBCUDACXX_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 #  define _LIBCUDACXX_TRAIT(__TRAIT, ...) __TRAIT<__VA_ARGS__>::value
 #endif
 
+#if defined(__CUDACC__) && !defined(_LIBCUDACXX_COMPILER_NVRTC)
+#define _LIBCUDACXX_DISABLE_EXEC_CHECK #pragma nv_exec_check_disable
+#else
+#define _LIBCUDACXX_DISABLE_EXEC_CHECK
+#endif
+
 #endif // __cplusplus
 
 #endif // _LIBCUDACXX_CONFIG

--- a/include/cuda/std/detail/libcxx/include/__functional/invoke.h
+++ b/include/cuda/std/detail/libcxx/include/__functional/invoke.h
@@ -338,9 +338,7 @@ _LIBCUDACXX_INLINE_VISIBILITY __nat __invoke(__any, _Args&& ...__args);
 
 // bullets 1, 2 and 3
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet1<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -349,9 +347,7 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     _NOEXCEPT_(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
     { return           (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...); }
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet2<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -360,9 +356,7 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     _NOEXCEPT_(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
     { return          (__a0.get().*__f)(static_cast<_Args&&>(__args)...); }
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet3<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -373,9 +367,7 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
 
 // bullets 4, 5 and 6
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0,
           class = __enable_if_bullet4<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -384,9 +376,7 @@ __invoke(_Fp&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept(static_cast<_A0&&>(__a0).*__f))
     { return          static_cast<_A0&&>(__a0).*__f; }
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0,
           class = __enable_if_bullet5<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -395,9 +385,7 @@ __invoke(_Fp&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept(__a0.get().*__f))
     { return          __a0.get().*__f; }
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class _A0,
           class = __enable_if_bullet6<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -408,9 +396,7 @@ __invoke(_Fp&& __f, _A0&& __a0)
 
 // bullet 7
 
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Fp, class ..._Args>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_Fp>()(_CUDA_VSTD::declval<_Args>()...))

--- a/include/cuda/std/detail/libcxx/include/__functional/invoke.h
+++ b/include/cuda/std/detail/libcxx/include/__functional/invoke.h
@@ -338,6 +338,9 @@ _LIBCUDACXX_INLINE_VISIBILITY __nat __invoke(__any, _Args&& ...__args);
 
 // bullets 1, 2 and 3
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet1<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -346,6 +349,9 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     _NOEXCEPT_(noexcept((static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...)))
     { return           (static_cast<_A0&&>(__a0).*__f)(static_cast<_Args&&>(__args)...); }
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet2<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -354,6 +360,9 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
     _NOEXCEPT_(noexcept((__a0.get().*__f)(static_cast<_Args&&>(__args)...)))
     { return          (__a0.get().*__f)(static_cast<_Args&&>(__args)...); }
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class _A0, class ..._Args,
           class = __enable_if_bullet3<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -364,6 +373,9 @@ __invoke(_Fp&& __f, _A0&& __a0, _Args&& ...__args)
 
 // bullets 4, 5 and 6
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class _A0,
           class = __enable_if_bullet4<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -372,6 +384,9 @@ __invoke(_Fp&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept(static_cast<_A0&&>(__a0).*__f))
     { return          static_cast<_A0&&>(__a0).*__f; }
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class _A0,
           class = __enable_if_bullet5<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -380,6 +395,9 @@ __invoke(_Fp&& __f, _A0&& __a0)
     _NOEXCEPT_(noexcept(__a0.get().*__f))
     { return          __a0.get().*__f; }
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class _A0,
           class = __enable_if_bullet6<_Fp, _A0> >
 inline _LIBCUDACXX_INLINE_VISIBILITY
@@ -390,6 +408,9 @@ __invoke(_Fp&& __f, _A0&& __a0)
 
 // bullet 7
 
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
 template <class _Fp, class ..._Args>
 inline _LIBCUDACXX_INLINE_VISIBILITY
 _LIBCUDACXX_CONSTEXPR decltype(_CUDA_VSTD::declval<_Fp>()(_CUDA_VSTD::declval<_Args>()...))

--- a/include/cuda/std/detail/libcxx/include/__memory/construct_at.h
+++ b/include/cuda/std/detail/libcxx/include/__memory/construct_at.h
@@ -58,9 +58,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // construct_at
 #if _LIBCUDACXX_STD_VER > 17
 
-#if defined(__CUDACC__)
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Tp, class... _Args, class = decltype(::new(_CUDA_VSTD::declval<void*>()) _Tp(_CUDA_VSTD::declval<_Args>()...))>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 __enable_if_t<!is_trivially_constructible_v<_Tp, _Args...>, _Tp*> construct_at(_Tp* __location, _Args&&... __args) {
@@ -84,9 +82,7 @@ __enable_if_t<is_trivially_constructible_v<_Tp, _Args...>, _Tp*> construct_at(_T
 
 #endif // _LIBCUDACXX_STD_VER > 17
 
-#if defined(__CUDACC__)
-#pragma nv_exec_check_disable
-#endif
+_LIBCUDACXX_DISABLE_EXEC_CHECK
 template <class _Tp, class... _Args, class = decltype(::new(_CUDA_VSTD::declval<void*>()) _Tp(_CUDA_VSTD::declval<_Args>()...))>
 _LIBCUDACXX_INLINE_VISIBILITY _LIBCUDACXX_CONSTEXPR_AFTER_CXX17
 __enable_if_t<!_LIBCUDACXX_TRAIT(is_trivially_constructible, _Tp, _Args...), _Tp*> __construct_at(_Tp* __location, _Args&&... __args) {


### PR DESCRIPTION
Use pragma suggested by @jrhemstad to disable execution checks in `cuda::proclaim_return_type`. This fixes a problem with nested device lambdas. Resolves #447.

I'm not familiar with the layout of libcudacxx so I'm not sure what kind of test is appropriate to add here.

There is a minimal reproducer at https://godbolt.org/z/oaMhrcoPv, also noted in issue #447. I tested this locally with a more complex source file from libcudf ([see here](https://github.com/rapidsai/cudf/pull/13222/commits/9e4c832d381507d9637e8134b039bdd230f7b749)) and it compiled successfully after applying this patch.