### PR TITLE
Fix link to std::binary_semaphore documentation

### DIFF
--- a/docs/extended_api/synchronization_primitives/binary_semaphore.md
+++ b/docs/extended_api/synchronization_primitives/binary_semaphore.md
@@ -71,7 +71,7 @@ __global__ void example_kernel() {
 
 [`cuda::thread_scope`]: ../memory_model.md
 
-[`cuda::std::binary_semaphore`]: https://en.cppreference.com/w/cpp/thread/binary_semaphore
+[`cuda::std::binary_semaphore`]: https://en.cppreference.com/w/cpp/thread/counting_semaphore
 
 [`concurrentManagedAccess` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_116f9619ccc85e93bc456b8c69c80e78b
 [`hostNativeAtomicSupported` property]: https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1ef82fd7d1d0413c7d6f33287e5b6306f


### PR DESCRIPTION
Previous link points at empty page as cppreference documentation was merged with the page for std::counting_semaphore.