### PR TITLE
Fix atomic_ref example

### DIFF
--- a/docs/extended_api/synchronization_primitives/atomic_ref.md
+++ b/docs/extended_api/synchronization_primitives/atomic_ref.md
@@ -74,7 +74,7 @@ __global__ void example_kernel(int *gmem, int *pinned_mem) {
 
   __shared__ int shared_v;
   // This atomic is suitable for threads in the same thread block.
-  cuda::atomic_ref<int, cuda::thread_scope_block> d(&shared);
+  cuda::atomic_ref<int, cuda::thread_scope_block> d(shared_v);
 }
 ```
 


### PR DESCRIPTION
Very small fix of variable name and reference vs pointer.