### PR TITLE
Replace diag_suppress by nv_diag_suppress in documentation

### DIFF
--- a/docs/extended_api/synchronization_primitives/barrier.md
+++ b/docs/extended_api/synchronization_primitives/barrier.md
@@ -34,7 +34,7 @@ warning: dynamic initialization is not supported for a function-scope static
 __shared__ variable within a __device__/__global__ function
 ```
 
-It can be silenced using `#pragma diag_suppress static_var_with_dynamic_init`.
+It can be silenced using `#pragma nv_diag_suppress static_var_with_dynamic_init`.
 
 To properly initialize a `__shared__` `cuda::barrier`, use the
   [`cuda::barrier::init`] friend function.

--- a/docs/extended_api/synchronization_primitives/barrier/init.md
+++ b/docs/extended_api/synchronization_primitives/barrier/init.md
@@ -36,7 +36,7 @@ warning: dynamic initialization is not supported for a function-scope static
 __shared__ variable within a __device__/__global__ function
 ```
 
-It can be silenced using `#pragma diag_suppress static_var_with_dynamic_init`.
+It can be silenced using `#pragma nv_diag_suppress static_var_with_dynamic_init`.
 
 ## Example
 
@@ -44,7 +44,7 @@ It can be silenced using `#pragma diag_suppress static_var_with_dynamic_init`.
 #include <cuda/barrier>
 
 // Disables `pipeline_shared_state` initialization warning.
-#pragma diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress static_var_with_dynamic_init
 
 __global__ void example_kernel() {
   __shared__ cuda::barrier<cuda::thread_scope_block> bar;

--- a/docs/extended_api/synchronization_primitives/make_pipeline.md
+++ b/docs/extended_api/synchronization_primitives/make_pipeline.md
@@ -88,7 +88,7 @@ A `cuda::pipeline` object.
 #include <cooperative_groups.h>
 
 // Disables `pipeline_shared_state` initialization warning.
-#pragma diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress static_var_with_dynamic_init
 
 __global__ void example_kernel() {
   __shared__ cuda::pipeline_shared_state<cuda::thread_scope_block, 2> pss0;

--- a/docs/extended_api/synchronization_primitives/pipeline.md
+++ b/docs/extended_api/synchronization_primitives/pipeline.md
@@ -86,7 +86,7 @@ A thread role cannot change during the lifetime of the pipeline object.
 #include <cooperative_groups.h>
 
 // Disables `pipeline_shared_state` initialization warning.
-#pragma diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress static_var_with_dynamic_init
 
 template <typename T>
 __device__ void compute(T* ptr);

--- a/docs/extended_api/synchronization_primitives/pipeline_producer_commit.md
+++ b/docs/extended_api/synchronization_primitives/pipeline_producer_commit.md
@@ -35,7 +35,7 @@ If the pipeline is in a _quitted state_ (see [`cuda::pipeline::quit`]), the
 #include <cuda/pipeline>
 
 // Disables `barrier` initialization warning.
-#pragma diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress static_var_with_dynamic_init
 
 __global__ void
 example_kernel(cuda::std::uint64_t* global, cuda::std::size_t element_count) {

--- a/docs/extended_api/synchronization_primitives/pipeline_shared_state.md
+++ b/docs/extended_api/synchronization_primitives/pipeline_shared_state.md
@@ -47,7 +47,7 @@ warning: dynamic initialization is not supported for a function-scope static
 __shared__ variable within a __device__/__global__ function
 ```
 
-It can be silenced using `#pragma diag_suppress static_var_with_dynamic_init`.
+It can be silenced using `#pragma nv_diag_suppress static_var_with_dynamic_init`.
 
 ## Example
 
@@ -55,7 +55,7 @@ It can be silenced using `#pragma diag_suppress static_var_with_dynamic_init`.
 #include <cuda/pipeline>
 
 // Disables `pipeline_shared_state` initialization warning.
-#pragma diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress static_var_with_dynamic_init
 
 __global__ void example_kernel(char* device_buffer, char* sysmem_buffer) {
   // Allocate a 2 stage block scoped shared state in shared memory.

--- a/docs/extended_api/synchronization_primitives/pipeline_shared_state/constructor.md
+++ b/docs/extended_api/synchronization_primitives/pipeline_shared_state/constructor.md
@@ -26,7 +26,7 @@ Construct a [`cuda::pipeline`] _shared state_ object.
 ```cuda
 #include <cuda/pipeline>
 
-#pragma diag_suppress static_var_with_dynamic_init
+#pragma nv_diag_suppress static_var_with_dynamic_init
 
 __global__ void example_kernel() {
   __shared__ cuda::pipeline_shared_state<cuda::thread_scope_block, 2> shared_state;


### PR DESCRIPTION
Fix docs.

nvcc version 11 warns that `diag_suppress` is deprecated. Version 12 does not support it anymore. `nv_diag_suppress` works.

Godbolt example to try with different compiler versions: https://godbolt.org/z/nGnP95n8r