### PR TITLE
Make it clear that the documentation has been moved

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,6 +4,8 @@ has_toc: true
 nav_order: 5
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Contributing
 
 We welcome contributions - just send us a pull request!

--- a/docs/contributing/code_of_conduct.md
+++ b/docs/contributing/code_of_conduct.md
@@ -1,5 +1,7 @@
 # Code of Conduct
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 ## Overview
 
 This document defines the Code of Conduct followed and enforced for NVIDIA C++

--- a/docs/extended_api.md
+++ b/docs/extended_api.md
@@ -4,6 +4,8 @@ has_toc: false
 nav_order: 3
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Extended API
 
 ## Fundamentals

--- a/docs/extended_api/asynchronous_operations.md
+++ b/docs/extended_api/asynchronous_operations.md
@@ -1,5 +1,7 @@
 ## Asynchronous Operations
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 | [`cuda::memcpy_async`] | Asynchronously copies one range to another. `(function template)` <br/><br/> 1.1.0 / CUDA 11.0 <br/> 1.2.0 / CUDA 11.1 (group & aligned overloads) |
 
 

--- a/docs/extended_api/asynchronous_operations/memcpy_async.md
+++ b/docs/extended_api/asynchronous_operations/memcpy_async.md
@@ -3,6 +3,8 @@ grand_parent: Extended API
 parent: Asynchronous Operations
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::memcpy_async`
 
 Defined in header `<cuda/barrier>`:

--- a/docs/extended_api/functional.md
+++ b/docs/extended_api/functional.md
@@ -1,4 +1,5 @@
 ## Functional
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
 
 | [`cuda::proclaim_return_type`] | Creates a forwarding call wrapper that proclaims return type <br/><br/> 1.8.0 / CUDA 11.7 |
 

--- a/docs/extended_api/functional/proclaim_return_type.md
+++ b/docs/extended_api/functional/proclaim_return_type.md
@@ -3,6 +3,8 @@ grand_parent: Extended API
 parent: Functional
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::proclaim_return_type`
 
 Defined in the header `<cuda/functional>`:

--- a/docs/extended_api/memory_access_properties.md
+++ b/docs/extended_api/memory_access_properties.md
@@ -1,5 +1,7 @@
 ## Memory access properties
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 | [`cuda::annotated_ptr`]             | Binds an access property to a pointer. `(class template)` <br/><br/> 1.6.0 / CUDA 11.5 |
 | [`cuda::access_property`]           | Represents a memory access property. `(class)` <br/><br/> 1.6.0 / CUDA 11.5 |
 | [`cuda::apply_access_property`]     | Applies access property to memory location. `(function template)` <br/><br/> 1.6.0 / CUDA 11.5 |

--- a/docs/extended_api/memory_access_properties/access_property.md
+++ b/docs/extended_api/memory_access_properties/access_property.md
@@ -4,6 +4,8 @@ grand_parent: Extended API
 nav_order: 2
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::access_property`
 
 Defined in header `<cuda/annotated_ptr>`:

--- a/docs/extended_api/memory_access_properties/annotated_ptr.md
+++ b/docs/extended_api/memory_access_properties/annotated_ptr.md
@@ -4,6 +4,8 @@ grand_parent: Extended API
 nav_order: 1
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::annotated_ptr`
 
 Defined in header `<cuda/annotated_ptr>`:

--- a/docs/extended_api/memory_access_properties/apply_access_property.md
+++ b/docs/extended_api/memory_access_properties/apply_access_property.md
@@ -4,6 +4,8 @@ grand_parent: Extended API
 nav_order: 3
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::apply_access_property`
 
 ```cuda

--- a/docs/extended_api/memory_access_properties/associate_access_property.md
+++ b/docs/extended_api/memory_access_properties/associate_access_property.md
@@ -4,6 +4,8 @@ grand_parent: Extended API
 nav_order: 4
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::associate_access_property`
 
 ```cuda

--- a/docs/extended_api/memory_access_properties/discard_memory.md
+++ b/docs/extended_api/memory_access_properties/discard_memory.md
@@ -4,6 +4,8 @@ grand_parent: Extended API
 nav_order: 5
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::discard_memory`
 
 ```cuda

--- a/docs/extended_api/memory_model.md
+++ b/docs/extended_api/memory_model.md
@@ -3,6 +3,8 @@ parent: Extended API
 nav_order: 0
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Memory model
 
 Standard C++ presents a view that the cost to synchronize threads is uniform and low.

--- a/docs/extended_api/shapes.md
+++ b/docs/extended_api/shapes.md
@@ -1,5 +1,7 @@
 ## Shapes
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 | [`cuda::std::size_t`]    | Defines an extent of bytes. `(typedef)`                                            <br/><br/> 1.0.0 / CUDA 10.2 |
 | [`cuda::aligned_size_t`] | Defines an extent of bytes with a statically defined alignment. `(class template)` <br/><br/> 1.2.0 / CUDA 11.1 |
 

--- a/docs/extended_api/shapes/aligned_size_t.md
+++ b/docs/extended_api/shapes/aligned_size_t.md
@@ -3,6 +3,8 @@ grand_parent: Extended API
 parent: Shapes
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # `cuda::aligned_size_t`
 
 Defined in headers `<cuda/barrier>` and `<cuda/pipeline>`:

--- a/docs/extended_api/synchronization_primitives.md
+++ b/docs/extended_api/synchronization_primitives.md
@@ -1,5 +1,7 @@
 ## Synchronization Primitives
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 ### Atomics
 
 | [`cuda::atomic`]             | System-wide [`cuda::std::atomic`] objects and operations. `(class template)`                                   <br/><br/> 1.0.0 / CUDA 10.2 |

--- a/docs/extended_api/thread_groups.md
+++ b/docs/extended_api/thread_groups.md
@@ -3,6 +3,8 @@ parent: Extended API
 nav_order: 1
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Thread Groups
 
 ```cuda

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,4 @@
-:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates.** :warning:
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
 
 
 # libcu++: The C++ Standard Library for Your Entire System

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,8 @@ has_toc: true
 nav_order: 4
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Releases
 
 The latest ABI version is always the default.

--- a/docs/releases/changelog.md
+++ b/docs/releases/changelog.md
@@ -10,6 +10,9 @@ It pulls in the latest version of upstream libc++ and marks the beginning of
   automatic tracking of upstream.
 -->
 
+
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 ## libcu++ 2.1.0
 
 Adds `<cuda/std/span>`, `<cuda/std/mdspan>`, and `<cuda/std/concepts>` to libcu++.

--- a/docs/releases/versioning.md
+++ b/docs/releases/versioning.md
@@ -3,6 +3,8 @@ parent: Releases
 nav_order: 1
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Versioning
 
 libcu++ is versioned along two axes:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,4 +4,6 @@ has_toc: true
 nav_order: 1
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Setup

--- a/docs/setup/building_and_testing.md
+++ b/docs/setup/building_and_testing.md
@@ -3,6 +3,8 @@ parent: Setup
 nav_order: 2
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Building & Testing libcu++
 
 ## *nix Systems, Native Build/Test

--- a/docs/setup/getting.md
+++ b/docs/setup/getting.md
@@ -3,6 +3,8 @@ parent: Setup
 nav_order: 1
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Getting libcu++
 
 ## NVIDIA HPC SDK or CUDA Toolkit

--- a/docs/setup/requirements.md
+++ b/docs/setup/requirements.md
@@ -3,6 +3,8 @@ parent: Setup
 nav_order: 0
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Requirements
 
 All requirements are applicable to the `main` branch on GitHub.

--- a/docs/standard_api.md
+++ b/docs/standard_api.md
@@ -4,6 +4,8 @@ has_toc: false
 nav_order: 2
 ---
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 # Standard API
 
 ## Standard Library Backports

--- a/docs/standard_api/numerics_library.md
+++ b/docs/standard_api/numerics_library.md
@@ -1,5 +1,7 @@
 ## Numerics Library
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 Any Standard C++ header not listed below is omitted.
 
 | [`<cuda/std/complex>`](https://en.cppreference.com/w/cpp/header/complex)   | Complex number type (see also: [libcu++ Specifics]({{ "standard_api/numerics_library/complex.html" | relative_url }})). <br/><br/> 1.4.0 |

--- a/docs/standard_api/time_library.md
+++ b/docs/standard_api/time_library.md
@@ -1,5 +1,7 @@
 ## Time Library
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 Any Standard C++ header not listed below is omitted.
 
 *: Some of the Standard C++ facilities in this header are omitted, see the

--- a/docs/standard_api/utility_library.md
+++ b/docs/standard_api/utility_library.md
@@ -1,5 +1,7 @@
 ## Utility Library
 
+:warning: **The libcudacxx repository has been archived and is now part of the unified [nvidia/cccl repository](https://github.com/nvidia/cccl). See the [announcement here](https://github.com/NVIDIA/cccl/discussions/520) for more information. Please visit the new repository for the latest updates. The new documentation can be found [here](https://nvidia.github.io/cccl/libcudacxx/).** :warning:
+
 Any Standard C++ header not listed below is omitted.
 
 *: Some of the Standard C++ facilities in this header are omitted, see the


### PR DESCRIPTION
1. Point to new docs
2. Add warning in more places